### PR TITLE
Fix simple typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pg_ivm
 
-The `pg_ivm` module provides Incremnetal View Maintenance (IVM) feature for PostgreSQL. 
+The `pg_ivm` module provides Incremental View Maintenance (IVM) feature for PostgreSQL. 
 
 The extension is compatible with PostgreSQL 14.
 
@@ -54,7 +54,7 @@ postgres=# SELECT * FROM m; -- automatically updated
 (4 rows)
 ```
 
-## Installaion
+## Installation
 To install `pg_ivm`, execute this in the module's directory:
 
 ```shell


### PR DESCRIPTION
Incremnetal -> Incremental
Installaion -> Installation

The same typo also exists on GitHub repository description. It can be fixed by repo owners/admins using the Web interface.

![image](https://user-images.githubusercontent.com/6772247/161258960-fa82d1a1-5e29-4457-9489-a3a5971d7041.png)
