### PR TITLE
Make create_immv STRICT

### DIFF
--- a/pg_ivm--1.0.sql
+++ b/pg_ivm--1.0.sql
@@ -19,6 +19,7 @@ SELECT pg_catalog.pg_extension_config_dump('pg_catalog.pg_ivm_immv', '');
 
 CREATE FUNCTION create_immv(text, text)
 RETURNS bigint 
+STRICT
 AS 'MODULE_PATHNAME', 'create_immv'
 LANGUAGE C;
 


### PR DESCRIPTION
This currently crashes the server: `SELECT create_immv(NULL, 'SELECT * FROM test');` . 

Marking the function STRICT will avoid calling it with NULL arguments. (not sure if you have a SQL upgrade script policy yet)

Alternative would be check for NULL in create_immv.