### PR TITLE
Fix the test to grant create permissions on the public schema

### DIFF
--- a/expected/pg_ivm.out
+++ b/expected/pg_ivm.out
@@ -1,4 +1,5 @@
 CREATE EXTENSION pg_ivm;
+GRANT ALL ON SCHEMA public TO public;
 -- create a table to use as a basis for views and materialized views in various combinations
 CREATE TABLE mv_base_a (i int, j int);
 INSERT INTO mv_base_a VALUES

--- a/sql/pg_ivm.sql
+++ b/sql/pg_ivm.sql
@@ -1,4 +1,5 @@
 CREATE EXTENSION pg_ivm;
+GRANT ALL ON SCHEMA public TO public;
 
 -- create a table to use as a basis for views and materialized views in various combinations
 CREATE TABLE mv_base_a (i int, j int);


### PR DESCRIPTION
As of PG15, PUBLIC CREATE was revoked from public schema, so
we have to grant it in contrib_regression database.

Issue #11 