### PR TITLE
Add refresh_immv() function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PGFILEDESC = "pg_ivm - incremental view maintenance on PostgreSQL"
 EXTENSION = pg_ivm
 DATA = pg_ivm--1.0.sql
 
-REGRESS = pg_ivm create_immv
+REGRESS = pg_ivm create_immv refresh_immv
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/createas.c
+++ b/createas.c
@@ -69,7 +69,7 @@ static void check_ivm_restriction(Node *node);
 static bool check_ivm_restriction_walker(Node *node, check_ivm_restriction_context *context);
 static Bitmapset *get_primary_key_attnos_from_query(Query *query, List **constraintList, bool is_create);
 
-static void StoreImmvQuery(Oid viewOid, bool skipData, Query *viewQuery);
+static void StoreImmvQuery(Oid viewOid, bool ispopulated, Query *viewQuery);
 
 #if defined(PG_VERSION_NUM) && (PG_VERSION_NUM < 140000)
 static bool CreateTableAsRelExists(CreateTableAsStmt *ctas);
@@ -232,7 +232,7 @@ ExecCreateImmv(ParseState *pstate, CreateTableAsStmt *stmt,
 	}
 
 	/* Create the "view" part of an IMMV. */
-	StoreImmvQuery(address.objectId, into->skipData, viewQuery);
+	StoreImmvQuery(address.objectId, !into->skipData, viewQuery);
 
 	if (is_matview)
 	{
@@ -975,7 +975,7 @@ get_primary_key_attnos_from_query(Query *query, List **constraintList, bool is_c
  * Store the query for the IMMV to pg_ivwm_immv
  */
 static void
-StoreImmvQuery(Oid viewOid, bool withNoData, Query *viewQuery)
+StoreImmvQuery(Oid viewOid, bool ispopulated, Query *viewQuery)
 {
 	char   *querytree = nodeToString((Node *) viewQuery);
 	Datum values[Natts_pg_ivm_immv];
@@ -989,7 +989,7 @@ StoreImmvQuery(Oid viewOid, bool withNoData, Query *viewQuery)
 	memset(isNulls, false, sizeof(isNulls));
 
 	values[Anum_pg_ivm_immv_immvrelid -1 ] = ObjectIdGetDatum(viewOid);
-	values[Anum_pg_ivm_immv_withnodata -1 ] = BoolGetDatum(withNoData);
+	values[Anum_pg_ivm_immv_ispopulated -1 ] = BoolGetDatum(ispopulated);
 	values[Anum_pg_ivm_immv_viewdef -1 ] = CStringGetTextDatum(querytree);
 
 	pgIvmImmv = table_open(PgIvmImmvRelationId(), RowExclusiveLock);

--- a/createas.c
+++ b/createas.c
@@ -69,7 +69,7 @@ static void check_ivm_restriction(Node *node);
 static bool check_ivm_restriction_walker(Node *node, check_ivm_restriction_context *context);
 static Bitmapset *get_primary_key_attnos_from_query(Query *query, List **constraintList, bool is_create);
 
-static void StoreImmvQuery(Oid viewOid, Query *viewQuery);
+static void StoreImmvQuery(Oid viewOid, bool skipData, Query *viewQuery);
 
 #if defined(PG_VERSION_NUM) && (PG_VERSION_NUM < 140000)
 static bool CreateTableAsRelExists(CreateTableAsStmt *ctas);
@@ -232,7 +232,7 @@ ExecCreateImmv(ParseState *pstate, CreateTableAsStmt *stmt,
 	}
 
 	/* Create the "view" part of an IMMV. */
-	StoreImmvQuery(address.objectId, viewQuery);
+	StoreImmvQuery(address.objectId, into->skipData, viewQuery);
 
 	if (is_matview)
 	{
@@ -975,7 +975,7 @@ get_primary_key_attnos_from_query(Query *query, List **constraintList, bool is_c
  * Store the query for the IMMV to pg_ivwm_immv
  */
 static void
-StoreImmvQuery(Oid viewOid, Query *viewQuery)
+StoreImmvQuery(Oid viewOid, bool withNoData, Query *viewQuery)
 {
 	char   *querytree = nodeToString((Node *) viewQuery);
 	Datum values[Natts_pg_ivm_immv];
@@ -989,6 +989,7 @@ StoreImmvQuery(Oid viewOid, Query *viewQuery)
 	memset(isNulls, false, sizeof(isNulls));
 
 	values[Anum_pg_ivm_immv_immvrelid -1 ] = ObjectIdGetDatum(viewOid);
+	values[Anum_pg_ivm_immv_withnodata -1 ] = BoolGetDatum(withNoData);
 	values[Anum_pg_ivm_immv_viewdef -1 ] = CStringGetTextDatum(querytree);
 
 	pgIvmImmv = table_open(PgIvmImmvRelationId(), RowExclusiveLock);

--- a/expected/create_immv.out
+++ b/expected/create_immv.out
@@ -41,3 +41,4 @@ SELECT immvrelid FROM pg_ivm_immv ORDER BY 1;
 -----------
 (0 rows)
 
+DROP TABLE t;

--- a/expected/refresh_immv.out
+++ b/expected/refresh_immv.out
@@ -7,22 +7,23 @@ NOTICE:  created index "mv_index" on immv "mv"
            5
 (1 row)
 
-SELECT immvrelid, withnodata FROM pg_ivm_immv ORDER BY 1;
- immvrelid | withnodata 
------------+------------
- mv        | f
+SELECT immvrelid, ispopulated FROM pg_ivm_immv ORDER BY 1;
+ immvrelid | ispopulated 
+-----------+-------------
+ mv        | t
 (1 row)
 
-SELECT refresh_immv('mv', false);
+-- refresh immv without changing the ispopulated flag
+SELECT refresh_immv('mv', true);
  refresh_immv 
 --------------
             5
 (1 row)
 
-SELECT immvrelid, withnodata FROM pg_ivm_immv ORDER BY 1;
- immvrelid | withnodata 
------------+------------
- mv        | f
+SELECT immvrelid, ispopulated FROM pg_ivm_immv ORDER BY 1;
+ immvrelid | ispopulated 
+-----------+-------------
+ mv        | t
 (1 row)
 
 INSERT INTO t VALUES(6);
@@ -37,16 +38,17 @@ SELECT i FROM mv ORDER BY 1;
  6
 (6 rows)
 
-SELECT refresh_immv('mv', true);
+-- change ispopulated to False
+SELECT refresh_immv('mv', false);
  refresh_immv 
 --------------
             0
 (1 row)
 
-SELECT immvrelid, withnodata FROM pg_ivm_immv ORDER BY 1;
- immvrelid | withnodata 
------------+------------
- mv        | t
+SELECT immvrelid, ispopulated FROM pg_ivm_immv ORDER BY 1;
+ immvrelid | ispopulated 
+-----------+-------------
+ mv        | f
 (1 row)
 
 SELECT i FROM mv ORDER BY 1;
@@ -54,22 +56,24 @@ SELECT i FROM mv ORDER BY 1;
 ---
 (0 rows)
 
+-- immv remains empty
 INSERT INTO t VALUES(7);
 SELECT i FROM mv ORDER BY 1;
  i 
 ---
 (0 rows)
 
-SELECT refresh_immv('mv', false);
+-- chaneg ispopulated to True, immv is updated
+SELECT refresh_immv('mv', true);
  refresh_immv 
 --------------
             7
 (1 row)
 
-SELECT immvrelid, withnodata FROM pg_ivm_immv ORDER BY 1;
- immvrelid | withnodata 
------------+------------
- mv        | f
+SELECT immvrelid, ispopulated FROM pg_ivm_immv ORDER BY 1;
+ immvrelid | ispopulated 
+-----------+-------------
+ mv        | t
 (1 row)
 
 SELECT i FROM mv ORDER BY 1;
@@ -84,6 +88,7 @@ SELECT i FROM mv ORDER BY 1;
  7
 (7 rows)
 
+-- immediate maintenance
 INSERT INTO t VALUES(8);
 SELECT i FROM mv ORDER BY 1;
  i 

--- a/expected/refresh_immv.out
+++ b/expected/refresh_immv.out
@@ -1,0 +1,100 @@
+CREATE TABLE t (i int PRIMARY KEY);
+INSERT INTO t SELECT generate_series(1, 5);
+SELECT create_immv('mv', 'SELECT * FROM t');
+NOTICE:  created index "mv_index" on immv "mv"
+ create_immv 
+-------------
+           5
+(1 row)
+
+SELECT immvrelid, withnodata FROM pg_ivm_immv ORDER BY 1;
+ immvrelid | withnodata 
+-----------+------------
+ mv        | f
+(1 row)
+
+SELECT refresh_immv('mv', false);
+ refresh_immv 
+--------------
+            5
+(1 row)
+
+SELECT immvrelid, withnodata FROM pg_ivm_immv ORDER BY 1;
+ immvrelid | withnodata 
+-----------+------------
+ mv        | f
+(1 row)
+
+INSERT INTO t VALUES(6);
+SELECT i FROM mv ORDER BY 1;
+ i 
+---
+ 1
+ 2
+ 3
+ 4
+ 5
+ 6
+(6 rows)
+
+SELECT refresh_immv('mv', true);
+ refresh_immv 
+--------------
+            0
+(1 row)
+
+SELECT immvrelid, withnodata FROM pg_ivm_immv ORDER BY 1;
+ immvrelid | withnodata 
+-----------+------------
+ mv        | t
+(1 row)
+
+SELECT i FROM mv ORDER BY 1;
+ i 
+---
+(0 rows)
+
+INSERT INTO t VALUES(7);
+SELECT i FROM mv ORDER BY 1;
+ i 
+---
+(0 rows)
+
+SELECT refresh_immv('mv', false);
+ refresh_immv 
+--------------
+            7
+(1 row)
+
+SELECT immvrelid, withnodata FROM pg_ivm_immv ORDER BY 1;
+ immvrelid | withnodata 
+-----------+------------
+ mv        | f
+(1 row)
+
+SELECT i FROM mv ORDER BY 1;
+ i 
+---
+ 1
+ 2
+ 3
+ 4
+ 5
+ 6
+ 7
+(7 rows)
+
+INSERT INTO t VALUES(8);
+SELECT i FROM mv ORDER BY 1;
+ i 
+---
+ 1
+ 2
+ 3
+ 4
+ 5
+ 6
+ 7
+ 8
+(8 rows)
+

--- a/pg_ivm--1.0.sql
+++ b/pg_ivm--1.0.sql
@@ -4,7 +4,7 @@ CREATE SCHEMA __pg_ivm__;
 
 CREATE TABLE __pg_ivm__.pg_ivm_immv(
   immvrelid regclass NOT NULL,
-  withnodata bool NOT NULL,
+  ispopulated bool NOT NULL,
   viewdef text NOT NULL,
 
   CONSTRAINT pg_ivm_immv_pkey PRIMARY KEY (immvrelid)

--- a/pg_ivm--1.0.sql
+++ b/pg_ivm--1.0.sql
@@ -4,6 +4,7 @@ CREATE SCHEMA __pg_ivm__;
 
 CREATE TABLE __pg_ivm__.pg_ivm_immv(
   immvrelid regclass NOT NULL,
+  withnodata bool NOT NULL,
   viewdef text NOT NULL,
 
   CONSTRAINT pg_ivm_immv_pkey PRIMARY KEY (immvrelid)
@@ -21,6 +22,12 @@ CREATE FUNCTION create_immv(text, text)
 RETURNS bigint 
 STRICT
 AS 'MODULE_PATHNAME', 'create_immv'
+LANGUAGE C;
+
+CREATE FUNCTION refresh_immv(text, bool)
+RETURNS bigint 
+STRICT
+AS 'MODULE_PATHNAME', 'refresh_immv'
 LANGUAGE C;
 
 -- trigger functions

--- a/pg_ivm.c
+++ b/pg_ivm.c
@@ -156,7 +156,6 @@ create_immv(PG_FUNCTION_ARGS)
 {
 	text	*t_relname = PG_GETARG_TEXT_PP(0);
 	text	*t_sql = PG_GETARG_TEXT_PP(1);
-
 	char	*relname = text_to_cstring(t_relname);
 	char	*sql = text_to_cstring(t_sql);
 	List	*parsetree_list;
@@ -236,15 +235,14 @@ Datum
 refresh_immv(PG_FUNCTION_ARGS)
 {
 	text	*t_relname = PG_GETARG_TEXT_PP(0);
-	bool	skipData = PG_GETARG_BOOL(1);
+	bool	ispopulated = PG_GETARG_BOOL(1);
 	char	*relname = text_to_cstring(t_relname);
 	QueryCompletion qc;
 
-	ExecRefreshImmv( relname, skipData, &qc);
+	ExecRefreshImmv( relname, !(ispopulated), &qc);
 
 	PG_RETURN_INT64(qc.nprocessed);
 }
-
 
 /*
  * Create triggers to prevent IMMV from being changed
@@ -263,7 +261,6 @@ CreateChangePreventTrigger(Oid matviewOid)
 	refaddr.classId = RelationRelationId;
 	refaddr.objectId = matviewOid;
 	refaddr.objectSubId = 0;
- 
 
 	ivm_trigger = makeNode(CreateTrigStmt);
 	ivm_trigger->relation = NULL;

--- a/pg_ivm.h
+++ b/pg_ivm.h
@@ -19,10 +19,11 @@
 #include "tcop/dest.h"
 #include "utils/queryenvironment.h"
 
-#define Natts_pg_ivm_immv 2
+#define Natts_pg_ivm_immv 3
 
 #define Anum_pg_ivm_immv_immvrelid 1
-#define Anum_pg_ivm_immv_viewdef 2
+#define Anum_pg_ivm_immv_withnodata 2
+#define Anum_pg_ivm_immv_viewdef 3
 
 /* pg_ivm.c */
 
@@ -41,6 +42,8 @@ extern Query *rewriteQueryForIMMV(Query *query, List *colNames);
 
 /* matview.c */
 
+extern ObjectAddress ExecRefreshImmv(const char *relname, bool skipData, QueryCompletion *qc);
+//extern DestReceiver *CreateTransientRelDestReceiver(Oid oid);
 extern bool ImmvIncrementalMaintenanceIsEnabled(void);
 extern Datum IVM_immediate_before(PG_FUNCTION_ARGS);
 extern Datum IVM_immediate_maintenance(PG_FUNCTION_ARGS);

--- a/pg_ivm.h
+++ b/pg_ivm.h
@@ -22,7 +22,7 @@
 #define Natts_pg_ivm_immv 3
 
 #define Anum_pg_ivm_immv_immvrelid 1
-#define Anum_pg_ivm_immv_withnodata 2
+#define Anum_pg_ivm_immv_ispopulated 2
 #define Anum_pg_ivm_immv_viewdef 3
 
 /* pg_ivm.c */
@@ -43,7 +43,6 @@ extern Query *rewriteQueryForIMMV(Query *query, List *colNames);
 /* matview.c */
 
 extern ObjectAddress ExecRefreshImmv(const char *relname, bool skipData, QueryCompletion *qc);
-//extern DestReceiver *CreateTransientRelDestReceiver(Oid oid);
 extern bool ImmvIncrementalMaintenanceIsEnabled(void);
 extern Datum IVM_immediate_before(PG_FUNCTION_ARGS);
 extern Datum IVM_immediate_maintenance(PG_FUNCTION_ARGS);

--- a/sql/create_immv.sql
+++ b/sql/create_immv.sql
@@ -15,3 +15,5 @@ SELECT immvrelid FROM pg_ivm_immv ORDER BY 1;
 
 DROP TABLE mv2;
 SELECT immvrelid FROM pg_ivm_immv ORDER BY 1;
+
+DROP TABLE t;

--- a/sql/refresh_immv.sql
+++ b/sql/refresh_immv.sql
@@ -1,0 +1,27 @@
+CREATE TABLE t (i int PRIMARY KEY);
+INSERT INTO t SELECT generate_series(1, 5);
+
+SELECT create_immv('mv', 'SELECT * FROM t');
+
+SELECT immvrelid, withnodata FROM pg_ivm_immv ORDER BY 1;
+SELECT refresh_immv('mv', false);
+SELECT immvrelid, withnodata FROM pg_ivm_immv ORDER BY 1;
+
+INSERT INTO t VALUES(6);
+SELECT i FROM mv ORDER BY 1;
+
+SELECT refresh_immv('mv', true);
+SELECT immvrelid, withnodata FROM pg_ivm_immv ORDER BY 1;
+SELECT i FROM mv ORDER BY 1;
+
+INSERT INTO t VALUES(7);
+SELECT i FROM mv ORDER BY 1;
+
+SELECT refresh_immv('mv', false);
+SELECT immvrelid, withnodata FROM pg_ivm_immv ORDER BY 1;
+SELECT i FROM mv ORDER BY 1;
+
+INSERT INTO t VALUES(8);
+SELECT i FROM mv ORDER BY 1;
+
+

--- a/sql/refresh_immv.sql
+++ b/sql/refresh_immv.sql
@@ -2,26 +2,30 @@ CREATE TABLE t (i int PRIMARY KEY);
 INSERT INTO t SELECT generate_series(1, 5);
 
 SELECT create_immv('mv', 'SELECT * FROM t');
+SELECT immvrelid, ispopulated FROM pg_ivm_immv ORDER BY 1;
 
-SELECT immvrelid, withnodata FROM pg_ivm_immv ORDER BY 1;
-SELECT refresh_immv('mv', false);
-SELECT immvrelid, withnodata FROM pg_ivm_immv ORDER BY 1;
+-- refresh immv without changing the ispopulated flag
+SELECT refresh_immv('mv', true);
+SELECT immvrelid, ispopulated FROM pg_ivm_immv ORDER BY 1;
 
 INSERT INTO t VALUES(6);
 SELECT i FROM mv ORDER BY 1;
 
-SELECT refresh_immv('mv', true);
-SELECT immvrelid, withnodata FROM pg_ivm_immv ORDER BY 1;
+-- change ispopulated to False
+SELECT refresh_immv('mv', false);
+SELECT immvrelid, ispopulated FROM pg_ivm_immv ORDER BY 1;
 SELECT i FROM mv ORDER BY 1;
 
+-- immv remains empty
 INSERT INTO t VALUES(7);
 SELECT i FROM mv ORDER BY 1;
 
-SELECT refresh_immv('mv', false);
-SELECT immvrelid, withnodata FROM pg_ivm_immv ORDER BY 1;
+-- chaneg ispopulated to True, immv is updated
+SELECT refresh_immv('mv', true);
+SELECT immvrelid, ispopulated FROM pg_ivm_immv ORDER BY 1;
 SELECT i FROM mv ORDER BY 1;
 
+-- immediate maintenance
 INSERT INTO t VALUES(8);
 SELECT i FROM mv ORDER BY 1;
-
 


### PR DESCRIPTION
This patch add refresh command(without document).
refresh_immv(immv_name, with_no_data) has two argument. immv_name
is incrementaly matview name, and with_no_data is refresh command
option.

its with_no_data and WITH NO DATA option of REFRESH MATERIAEZED VIEW
mean the same. However, with_no_data has no data, but can be
referenced by SELECT.

e.g.
```
test=# CREATE TABLE test(id int);
CREATE TABLE
test=# INSERT INTO test SELECT generate_series(1, 5);
INSERT 0 5
test=# SELECT create_immv('immv', 'SELECT * FROM test');
NOTICE:  could not create an index on immv "immv" automatically
DETAIL:  This target list does not have all the primary key columns, or this view does not contain DISTINCT clause.
HINT:  Create an index on the immv for efficient incremental maintenance.
 create_immv 
-------------
           5
(1 row)

test=# SELECT refresh_immv('immv', true);
 refresh_immv 
--------------
            0
(1 row)

test=# SELECT * FROM immv;
 id 
----
(0 rows)
```
