### PR TITLE
Fix gcc warning in ExecRefreshImmv

### DIFF
--- a/matview.c
+++ b/matview.c
@@ -223,7 +223,7 @@ ExecRefreshImmv(const RangeVar *relation, bool skipData,
 {
 	Oid			matviewOid;
 	Relation	matviewRel;
-	Query	   *dataQuery;
+	Query	   *dataQuery = NULL; /* initialized to keep compiler happy */
 	Query	   *viewQuery;
 	Oid			tableSpace;
 	Oid			relowner;


### PR DESCRIPTION
I got a compiler warning on gcc 9.4.0:
```
matview.c: In function ‘ExecRefreshImmv’:                                                
matview.c:449:3: warning: ‘dataQuery’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  449 |   CreateIvmTriggersOnBaseTables(dataQuery, matviewOid, false);                   
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
```

Not a bug, just compiler not understanding that dataQuery is always initialized if !skipData.