### PR TITLE
Fix comment typo and test for aggregates without GROUP BY

### DIFF
--- a/createas.c
+++ b/createas.c
@@ -1078,7 +1078,7 @@ CreateIndexOnIMMV(Query *query, Relation matviewRel, bool is_create)
 
 
 	/*
-	 * For aggregate withoug GROUP BY, we do not need to create an index
+	 * For aggregate without GROUP BY, we do not need to create an index
 	 * because the view has only one row.
 	 */
 	if (query->hasAggs && query->groupClause == NIL)

--- a/expected/pg_ivm.out
+++ b/expected/pg_ivm.out
@@ -286,9 +286,6 @@ ROLLBACK;
 -- support aggregate functions without GROUP clause
 BEGIN;
 SELECT create_immv('mv_ivm_group',  'SELECT SUM(j), COUNT(j), AVG(j) FROM mv_base_a');
-NOTICE:  could not create an index on immv "mv_ivm_group" automatically
-DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
-HINT:  Create an index on the immv for efficient incremental maintenance.
  create_immv 
 -------------
            1
@@ -318,9 +315,6 @@ ROLLBACK;
 -- TRUNCATE a base table in aggregate views without GROUP clause
 BEGIN;
 SELECT create_immv('mv_ivm_group', 'SELECT SUM(j), COUNT(j), AVG(j) FROM mv_base_a');
-NOTICE:  could not create an index on immv "mv_ivm_group" automatically
-DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
-HINT:  Create an index on the immv for efficient incremental maintenance.
  create_immv 
 -------------
            1
@@ -437,9 +431,6 @@ ROLLBACK;
 -- support MIN(), MAX() aggregate functions without GROUP clause
 BEGIN;
 SELECT create_immv('mv_ivm_min_max', 'SELECT MIN(j), MAX(j)  FROM mv_base_a');
-NOTICE:  could not create an index on immv "mv_ivm_min_max" automatically
-DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
-HINT:  Create an index on the immv for efficient incremental maintenance.
  create_immv 
 -------------
            1


### PR DESCRIPTION
We usually try to create a unique index on an IMMV for both performance and constraint reasons. However, we don't need such index for an aggregate view without GROUP BY because it has always only one row. Also, we don't need to raise NOTICE message to suggest to create an index.

This change was mistakenly introduced in cfe9491e6b2168, but it should have been a separate commit. In this commit, a typo and tests are fixed.