### PR TITLE
Use snapshot to check tuple visibility in pre-update state

### DIFF
--- a/expected/pg_ivm.out
+++ b/expected/pg_ivm.out
@@ -518,6 +518,24 @@ SELECT * FROM mv_self ORDER BY v1;
  300 | 300
 (4 rows)
 
+--- with sub-transactions
+SAVEPOINT p1;
+INSERT INTO base_t VALUES (7,70);
+RELEASE SAVEPOINT p1;
+INSERT INTO base_t VALUES (7,77);
+SELECT * FROM mv_self ORDER BY v1, v2;
+ v1  | v2  
+-----+-----
+  50 |  50
+  60 |  60
+  70 |  70
+  70 |  77
+  77 |  70
+  77 |  77
+ 130 | 130
+ 300 | 300
+(8 rows)
+
 ROLLBACK;
 -- support simultaneous table changes
 BEGIN;

--- a/pg_ivm--1.2--1.3.sql
+++ b/pg_ivm--1.2--1.3.sql
@@ -1,0 +1,7 @@
+-- functions
+
+CREATE FUNCTION ivm_visible_in_prestate(oid, tid, oid)
+RETURNS bool
+STABLE
+AS 'MODULE_PATHNAME', 'ivm_visible_in_prestate'
+LANGUAGE C;

--- a/pg_ivm.h
+++ b/pg_ivm.h
@@ -49,6 +49,7 @@ extern bool ImmvIncrementalMaintenanceIsEnabled(void);
 extern Query *get_immv_query(Relation matviewRel);
 extern Datum IVM_immediate_before(PG_FUNCTION_ARGS);
 extern Datum IVM_immediate_maintenance(PG_FUNCTION_ARGS);
+extern Datum ivm_visible_in_prestate(PG_FUNCTION_ARGS);
 extern void AtAbort_IVM(void);
 extern bool isIvmName(const char *s);
 

--- a/sql/pg_ivm.sql
+++ b/sql/pg_ivm.sql
@@ -168,6 +168,14 @@ WITH
  dlt_t AS (DELETE FROM base_t WHERE i IN (4,5)  RETURNING 1)
 SELECT NULL;
 SELECT * FROM mv_self ORDER BY v1;
+
+--- with sub-transactions
+SAVEPOINT p1;
+INSERT INTO base_t VALUES (7,70);
+RELEASE SAVEPOINT p1;
+INSERT INTO base_t VALUES (7,77);
+SELECT * FROM mv_self ORDER BY v1, v2;
+
 ROLLBACK;
 
 -- support simultaneous table changes


### PR DESCRIPTION
When multiple tables are updated or the view contains a self-join, we need to calculate table states that was before it is modified during incremental view maintenance. For get the pre-update state, tuples inserted in a command must be removed when the table is scanned.

Previously, we used xmin and cmin system columns for this purpose, but this way is problematic because after a tuple is frozen, its xmin no longer has any meaning. Actually, we will get inconsistent view results after XID wraparound.

Also, we can see similar similar inconsistency when using sub-transaction because xmin values do not always monotonically increasing by command executions.

To fix this, we use a snapshot that taken just before the table is modified for checking tuple visibility in pre-state table instead of using xmin and cmin system columns. A new function returning boolean, ivm_visible_in_prestate, is added, and this is called in WHERE clause of sub-queries to calculate pre-state table. This function check if a specified tuple in the post-update table is visible or not using the snapshot and return true if the tuple is visible.