### PR TITLE
Fix a bug of automatic index creation

### DIFF
--- a/expected/pg_ivm.out
+++ b/expected/pg_ivm.out
@@ -1034,6 +1034,54 @@ drop cascades to table ivm_rls2
 DROP TABLE num_tbl CASCADE;
 DROP USER ivm_user;
 DROP USER ivm_admin;
+-- automatic index creation
+BEGIN;
+CREATE TABLE base_a (i int primary key, j int);
+CREATE TABLE base_b (i int primary key, j int);
+--- group by: create an index
+SELECT create_immv('mv_idx1', 'SELECT i, sum(j) FROM base_a GROUP BY i');
+NOTICE:  created index "mv_idx1_index" on immv "mv_idx1"
+ create_immv 
+-------------
+           0
+(1 row)
+
+--- distinct: create an index
+SELECT create_immv('mv_idx2', 'SELECT DISTINCT j FROM base_a');
+NOTICE:  created index "mv_idx2_index" on immv "mv_idx2"
+ create_immv 
+-------------
+           0
+(1 row)
+
+--- with all pkey columns: create an index
+SELECT create_immv('mv_idx3(i_a, i_b)', 'SELECT a.i, b.i FROM base_a a, base_b b');
+NOTICE:  created index "mv_idx3_index" on immv "mv_idx3"
+ create_immv 
+-------------
+           0
+(1 row)
+
+--- missing some pkey columns: no index
+SELECT create_immv('mv_idx4', 'SELECT j FROM base_a');
+NOTICE:  could not create an index on immv "mv_idx4" automatically
+DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
+HINT:  Create an index on the immv for efficient incremental maintenance.
+ create_immv 
+-------------
+           0
+(1 row)
+
+SELECT create_immv('mv_idx5', 'SELECT a.i, b.j FROM base_a a, base_b b');
+NOTICE:  could not create an index on immv "mv_idx5" automatically
+DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
+HINT:  Create an index on the immv for efficient incremental maintenance.
+ create_immv 
+-------------
+           0
+(1 row)
+
+ROLLBACK;
 -- prevent IMMV chanages
 INSERT INTO mv_ivm_1 VALUES(1,1,1);
 ERROR:  cannot change materialized view "mv_ivm_1"

--- a/sql/pg_ivm.sql
+++ b/sql/pg_ivm.sql
@@ -454,6 +454,25 @@ DROP TABLE num_tbl CASCADE;
 DROP USER ivm_user;
 DROP USER ivm_admin;
 
+-- automatic index creation
+BEGIN;
+CREATE TABLE base_a (i int primary key, j int);
+CREATE TABLE base_b (i int primary key, j int);
+
+--- group by: create an index
+SELECT create_immv('mv_idx1', 'SELECT i, sum(j) FROM base_a GROUP BY i');
+
+--- distinct: create an index
+SELECT create_immv('mv_idx2', 'SELECT DISTINCT j FROM base_a');
+
+--- with all pkey columns: create an index
+SELECT create_immv('mv_idx3(i_a, i_b)', 'SELECT a.i, b.i FROM base_a a, base_b b');
+
+--- missing some pkey columns: no index
+SELECT create_immv('mv_idx4', 'SELECT j FROM base_a');
+SELECT create_immv('mv_idx5', 'SELECT a.i, b.j FROM base_a a, base_b b');
+ROLLBACK;
+
 -- prevent IMMV chanages
 INSERT INTO mv_ivm_1 VALUES(1,1,1);
 UPDATE  mv_ivm_1 SET k = 1 WHERE i = 1;


### PR DESCRIPTION
It is intended that a unique index is created only if all primary keys of tables in FROM clause appear in the target list. For this purpose, pull_varnos_of_level was used to extract relations in the FROM clause, but it is incorrect and actually we should use get_relids_in_jointree.

Due to this bug, an index could be created even even where there is a pkey attribute from just one of relations in FROM clause.