### PR TITLE
Fix bugs of IVM that occur when column names are specified in aggrega…

### DIFF
--- a/expected/pg_ivm.out
+++ b/expected/pg_ivm.out
@@ -465,6 +465,55 @@ SELECT * FROM mv_ivm_min_max;
 (1 row)
 
 ROLLBACK;
+-- aggregate views with column names specified
+BEGIN;
+SELECT create_immv('mv_ivm_agg(a)', 'SELECT i, SUM(j) FROM mv_base_a GROUP BY i');
+NOTICE:  created index "mv_ivm_agg_index" on immv "mv_ivm_agg"
+ create_immv 
+-------------
+           5
+(1 row)
+
+INSERT INTO mv_base_a VALUES (1,100), (2,200), (3,300);
+UPDATE mv_base_a SET j = 2000 WHERE (i,j) = (2,20);
+DELETE FROM mv_base_a WHERE (i,j) = (3,30);
+SELECT * FROM mv_ivm_agg ORDER BY 1,2;
+ a | sum  | __ivm_count_sum__ | __ivm_count__ 
+---+------+-------------------+---------------
+ 1 |  110 |                 2 |             2
+ 2 | 2200 |                 2 |             2
+ 3 |  300 |                 1 |             1
+ 4 |   40 |                 1 |             1
+ 5 |   50 |                 1 |             1
+(5 rows)
+
+ROLLBACK;
+BEGIN;
+SELECT create_immv('mv_ivm_agg(a,b)', 'SELECT i, SUM(j) FROM mv_base_a GROUP BY i');
+NOTICE:  created index "mv_ivm_agg_index" on immv "mv_ivm_agg"
+ create_immv 
+-------------
+           5
+(1 row)
+
+INSERT INTO mv_base_a VALUES (1,100), (2,200), (3,300);
+UPDATE mv_base_a SET j = 2000 WHERE (i,j) = (2,20);
+DELETE FROM mv_base_a WHERE (i,j) = (3,30);
+SELECT * FROM mv_ivm_agg ORDER BY 1,2;
+ a |  b   | __ivm_count_b__ | __ivm_count__ 
+---+------+-----------------+---------------
+ 1 |  110 |               2 |             2
+ 2 | 2200 |               2 |             2
+ 3 |  300 |               1 |             1
+ 4 |   40 |               1 |             1
+ 5 |   50 |               1 |             1
+(5 rows)
+
+ROLLBACK;
+BEGIN;
+SELECT create_immv('mv_ivm_agg(a,b,c)', 'SELECT i, SUM(j) FROM mv_base_a GROUP BY i');
+ERROR:  too many column names were specified
+ROLLBACK;
 -- support self join view and multiple change on the same table
 BEGIN;
 CREATE TABLE base_t (i int, v int);

--- a/pg_ivm.c
+++ b/pg_ivm.c
@@ -224,7 +224,7 @@ create_immv(PG_FUNCTION_ARGS)
 	query = transformStmt(pstate, (Node *)ctas);
 	Assert(query->commandType == CMD_UTILITY && IsA(query->utilityStmt, CreateTableAsStmt));
 
-	ExecCreateImmv(pstate, (CreateTableAsStmt *)query->utilityStmt, NULL, NULL, &qc);
+	ExecCreateImmv(pstate, (CreateTableAsStmt *) query->utilityStmt, NULL, NULL, &qc);
 
 	PG_RETURN_INT64(qc.nprocessed);
 }

--- a/sql/pg_ivm.sql
+++ b/sql/pg_ivm.sql
@@ -150,6 +150,25 @@ DELETE FROM mv_base_a;
 SELECT * FROM mv_ivm_min_max;
 ROLLBACK;
 
+-- aggregate views with column names specified
+BEGIN;
+SELECT create_immv('mv_ivm_agg(a)', 'SELECT i, SUM(j) FROM mv_base_a GROUP BY i');
+INSERT INTO mv_base_a VALUES (1,100), (2,200), (3,300);
+UPDATE mv_base_a SET j = 2000 WHERE (i,j) = (2,20);
+DELETE FROM mv_base_a WHERE (i,j) = (3,30);
+SELECT * FROM mv_ivm_agg ORDER BY 1,2;
+ROLLBACK;
+BEGIN;
+SELECT create_immv('mv_ivm_agg(a,b)', 'SELECT i, SUM(j) FROM mv_base_a GROUP BY i');
+INSERT INTO mv_base_a VALUES (1,100), (2,200), (3,300);
+UPDATE mv_base_a SET j = 2000 WHERE (i,j) = (2,20);
+DELETE FROM mv_base_a WHERE (i,j) = (3,30);
+SELECT * FROM mv_ivm_agg ORDER BY 1,2;
+ROLLBACK;
+BEGIN;
+SELECT create_immv('mv_ivm_agg(a,b,c)', 'SELECT i, SUM(j) FROM mv_base_a GROUP BY i');
+ROLLBACK;
+
 -- support self join view and multiple change on the same table
 BEGIN;
 CREATE TABLE base_t (i int, v int);


### PR DESCRIPTION
…te views

The names of additional columns for aggregate views are derived from column names specified in the first parameter of create_immv, but when the number was less than the length of the actual target list, segmentation fault occurred. Furthermore, when the number of specified columns is more than the target list, it overrode additional column names and it caused a failure of incremental maintenance of an aggregate view.

To fix then, check the length of the specified column name list not to access invalid area, and also prevent from overriding additional column names.