### PR TITLE
Fix automatic index creation to support subqueries

### DIFF
--- a/createas.c
+++ b/createas.c
@@ -1326,8 +1326,14 @@ get_primary_key_attnos_from_query(Query *query, List **constraintList, bool is_c
 		/* skip NEW/OLD entries */
 		if (i >= first_rtindex)
 		{
+			/* for subqueries, scan recursively */
+			if (r->rtekind == RTE_SUBQUERY)
+			{
+				key_attnos = get_primary_key_attnos_from_query(r->subquery, constraintList, true);
+				has_pkey = (key_attnos != NULL);
+			}
 			/* for tables, call get_primary_key_attnos */
-			if (r->rtekind == RTE_RELATION)
+			else if (r->rtekind == RTE_RELATION)
 			{
 				Oid constraintOid;
 				key_attnos = get_primary_key_attnos(r->relid, false, &constraintOid);

--- a/expected/pg_ivm.out
+++ b/expected/pg_ivm.out
@@ -1130,6 +1130,14 @@ HINT:  Create an index on the immv for efficient incremental maintenance.
            0
 (1 row)
 
+--- subqueries
+SELECT create_immv('mv_idx6(i_a, i_b)', 'SELECT a.i, b.i FROM (SELECT * FROM base_a) a, (SELECT * FROM base_b) b');
+NOTICE:  created index "mv_idx6_index" on immv "mv_idx6"
+ create_immv 
+-------------
+           0
+(1 row)
+
 ROLLBACK;
 -- prevent IMMV chanages
 INSERT INTO mv_ivm_1 VALUES(1,1,1);

--- a/sql/pg_ivm.sql
+++ b/sql/pg_ivm.sql
@@ -490,6 +490,9 @@ SELECT create_immv('mv_idx3(i_a, i_b)', 'SELECT a.i, b.i FROM base_a a, base_b b
 --- missing some pkey columns: no index
 SELECT create_immv('mv_idx4', 'SELECT j FROM base_a');
 SELECT create_immv('mv_idx5', 'SELECT a.i, b.j FROM base_a a, base_b b');
+
+--- subqueries
+SELECT create_immv('mv_idx6(i_a, i_b)', 'SELECT a.i, b.i FROM (SELECT * FROM base_a) a, (SELECT * FROM base_b) b');
 ROLLBACK;
 
 -- prevent IMMV chanages


### PR DESCRIPTION
Previously, when a subquery is used a unique index could not be created even if all primary key attributes appear in the target list.