### PR TITLE
Add CTE support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ OBJS = \
 	createas.o \
 	matview.o \
 	pg_ivm.o \
-	ruleutils.o
+	ruleutils.o \
+	subselect.o
 PGFILEDESC = "pg_ivm - incremental view maintenance on PostgreSQL"
 
 EXTENSION = pg_ivm

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Time: 3224.741 ms (00:03.225)
 
 ## Supported View Definitions and Restriction
 
-Currently, IMMV's view definition can contain inner joins, DISTINCT clause, some built-in aggregate functions, and simple sub-queries in `FROM` clause. Inner joins including self-join are supported, but outer joins are not supported. Supported aggregate functions are count, sum, avg, min and max. Other aggregates, sub-queries which contain an aggregate or `DISTINCT` clause, sub-queries in other than `FROM` clause, CTEs, window functions, `HAVING`, `ORDER BY`, `LIMIT`/`OFFSET`, `UNION`/`INTERSECT`/`EXCEPT`, `DISTINCT ON`, `TABLESAMPLE`, `VALUES`, and `FOR UPDATE`/`SHARE` can not be used in view definition.
+Currently, IMMV's view definition can contain inner joins, DISTINCT clause, some built-in aggregate functions, simple sub-queries in `FROM` clause, and simple CTE (`WITH` query). Inner joins including self-join are supported, but outer joins are not supported. Supported aggregate functions are count, sum, avg, min and max. Other aggregates, sub-queries which contain an aggregate or `DISTINCT` clause, sub-queries in other than `FROM` clause, window functions, `HAVING`, `ORDER BY`, `LIMIT`/`OFFSET`, `UNION`/`INTERSECT`/`EXCEPT`, `DISTINCT ON`, `TABLESAMPLE`, `VALUES`, and `FOR UPDATE`/`SHARE` can not be used in view definition.
 
 The base tables must be simple tables. Views, materialized views, inheritance parent tables, partitioned tables, partitions, and foreign tables can not be used.
 
@@ -223,6 +223,16 @@ Simple subqueries in `FROM` clause are supported.
 Subqueries can be used only in `FROM` clause. Subqueries in target list or `WHERE` clause are not supported.
 
 Subqueries containing an aggregate function or `DISTINCT` are not supported.
+
+### CTE
+
+Simple CTEs (`WITH` queries) are supported.
+
+#### Restrictions on Subqueries
+
+`WITH` queries containing an aggregate function or `DISTINCT` are not supported.
+
+Recursive queries (`WITH RECURSIVE`) are not allowed. Unreferenced CTEs are not allowed either, that is, a CTE must be referenced at least once in the view definition query.
 
 ### DISTINCT
 

--- a/expected/pg_ivm.out
+++ b/expected/pg_ivm.out
@@ -843,6 +843,31 @@ SELECT * FROM mv_cte ORDER BY i,j;
 ROLLBACK;
 BEGIN;
 SELECT create_immv('mv_cte',
+    'WITH b AS ( SELECT * FROM (SELECT * FROM mv_base_b) b2) SELECT v.i,v.j FROM (WITH a AS (SELECT * FROM mv_base_a) SELECT a.i,a.j FROM a, b WHERE a.i = b.i) v');
+NOTICE:  could not create an index on immv "mv_cte" automatically
+DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
+HINT:  Create an index on the immv for efficient incremental maintenance.
+ create_immv 
+-------------
+           4
+(1 row)
+
+INSERT INTO mv_base_a VALUES(2,20);
+INSERT INTO mv_base_b VALUES(3,300);
+SELECT * FROM mv_cte ORDER BY i,j;
+ i | j  
+---+----
+ 1 | 10
+ 2 | 20
+ 2 | 20
+ 3 | 30
+ 3 | 30
+ 4 | 40
+(6 rows)
+
+ROLLBACK;
+BEGIN;
+SELECT create_immv('mv_cte',
     'WITH x AS ( SELECT i, a.j, b.k FROM mv_base_b b INNER JOIN mv_base_a a USING(i)) SELECT * FROM x');
 NOTICE:  could not create an index on immv "mv_cte" automatically
 DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
@@ -873,7 +898,12 @@ SELECT * FROM mv_cte ORDER BY i,j,k;
  3 | 30 | 133
 (8 rows)
 
-ROLLBACK;
+END; -- don't remove for get_immv_def test
+--- disallow not-simple CTE
+SELECT create_immv('mv_cte_fail', 'WITH b AS (SELECT i, COUNT(*) FROM mv_base_b GROUP BY i) SELECT a.i,a.j FROM mv_base_a a, b WHERE a.i = b.i');
+ERROR:  aggregate functions in nested query are not supported on incrementally maintainable materialized view
+SELECT create_immv('mv_cte_fail', 'WITH b AS (SELECT DISTINCT i FROM mv_base_b) SELECT a.i,a.j FROM mv_base_a a, b WHERE a.i = b.i');
+ERROR:  DISTINCT clause in nested query are not supported on incrementally maintainable materialized view
 -- views including NULL
 BEGIN;
 CREATE TABLE base_t (i int, v int);
@@ -1051,17 +1081,6 @@ ROLLBACK;
 SELECT create_immv('mv(a,b)',
     'SELECT a.i, b.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i');
 ERROR:  OUTER JOIN is not supported on incrementally maintainable materialized view
--- CTE is not supported
-SELECT create_immv('mv',
-    'WITH b AS ( SELECT * FROM mv_base_b) SELECT a.i,a.j FROM mv_base_a a, b WHERE a.i = b.i;');
-NOTICE:  could not create an index on immv "mv" automatically
-DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
-HINT:  Create an index on the immv for efficient incremental maintenance.
- create_immv 
--------------
-           4
-(1 row)
-
 -- contain system column
 SELECT create_immv('mv_ivm01', 'SELECT i,j,xmin FROM mv_base_a');
 ERROR:  system column is not supported on incrementally maintainable materialized view
@@ -1296,23 +1315,24 @@ TRUNCATE mv_ivm_1;
 ERROR:  cannot change materialized view "mv_ivm_1"
 -- get_immv_def function
 SELECT immvrelid, get_immv_def(immvrelid) FROM pg_ivm_immv ORDER BY 1;
- immvrelid |           get_immv_def           
------------+----------------------------------
- mv_ivm_1  |  SELECT a.i,                    +
-           |     a.j,                        +
-           |     b.k                         +
-           |    FROM (mv_base_a a            +
+ immvrelid |               get_immv_def               
+-----------+------------------------------------------
+ mv_ivm_1  |  SELECT a.i,                            +
+           |     a.j,                                +
+           |     b.k                                 +
+           |    FROM (mv_base_a a                    +
            |      JOIN mv_base_b b USING (i))
- mv        |  WITH b AS (                    +
-           |          SELECT mv_base_b.i,    +
-           |             mv_base_b.k         +
-           |            FROM mv_base_b       +
-           |         )                       +
-           |  SELECT a.i,                    +
-           |     a.j                         +
-           |    FROM mv_base_a a,            +
-           |     b                           +
-           |   WHERE (a.i = b.i)
+ mv_cte    |  WITH x AS (                            +
+           |          SELECT b.i,                    +
+           |             a.j,                        +
+           |             b.k                         +
+           |            FROM (mv_base_b b            +
+           |              JOIN mv_base_a a USING (i))+
+           |         )                               +
+           |  SELECT i,                              +
+           |     j,                                  +
+           |     k                                   +
+           |    FROM x
 (2 rows)
 
 -- mv_base_b is not immv
@@ -1325,7 +1345,7 @@ SELECT 'mv_base_b'::regclass, get_immv_def('mv_base_b');
 DROP TABLE mv_base_b CASCADE;
 NOTICE:  drop cascades to 4 other objects
 DETAIL:  drop cascades to table mv_ivm_1
-drop cascades to table mv
+drop cascades to table mv_cte
 drop cascades to view b_view
 drop cascades to materialized view b_mview
 DROP TABLE mv_base_a CASCADE;

--- a/expected/pg_ivm.out
+++ b/expected/pg_ivm.out
@@ -740,6 +740,140 @@ SELECT * FROM mv_ivm_join_subquery ORDER BY i,j,k;
 (8 rows)
 
 ROLLBACK;
+-- support simple CTE
+BEGIN;
+SELECT create_immv('mv_cte',
+    'WITH b AS ( SELECT * FROM mv_base_b) SELECT a.i,a.j FROM mv_base_a a, b WHERE a.i = b.i');
+NOTICE:  could not create an index on immv "mv_cte" automatically
+DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
+HINT:  Create an index on the immv for efficient incremental maintenance.
+ create_immv 
+-------------
+           4
+(1 row)
+
+INSERT INTO mv_base_a VALUES(2,20);
+INSERT INTO mv_base_b VALUES(3,300);
+SELECT * FROM mv_cte ORDER BY i,j;
+ i | j  
+---+----
+ 1 | 10
+ 2 | 20
+ 2 | 20
+ 3 | 30
+ 3 | 30
+ 4 | 40
+(6 rows)
+
+ROLLBACK;
+BEGIN;
+SELECT create_immv('mv_cte',
+    'WITH a AS (SELECT * FROM mv_base_a), b AS ( SELECT * FROM mv_base_b) SELECT a.i,a.j FROM a, b WHERE a.i = b.i');
+NOTICE:  could not create an index on immv "mv_cte" automatically
+DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
+HINT:  Create an index on the immv for efficient incremental maintenance.
+ create_immv 
+-------------
+           4
+(1 row)
+
+INSERT INTO mv_base_a VALUES(2,20);
+INSERT INTO mv_base_b VALUES(3,300);
+SELECT * FROM mv_cte ORDER BY i,j;
+ i | j  
+---+----
+ 1 | 10
+ 2 | 20
+ 2 | 20
+ 3 | 30
+ 3 | 30
+ 4 | 40
+(6 rows)
+
+ROLLBACK;
+BEGIN;
+SELECT create_immv('mv_cte',
+    'WITH b AS ( SELECT * FROM mv_base_b) SELECT v.i,v.j FROM (WITH a AS (SELECT * FROM mv_base_a) SELECT a.i,a.j FROM a, b WHERE a.i = b.i) v');
+NOTICE:  could not create an index on immv "mv_cte" automatically
+DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
+HINT:  Create an index on the immv for efficient incremental maintenance.
+ create_immv 
+-------------
+           4
+(1 row)
+
+INSERT INTO mv_base_a VALUES(2,20);
+INSERT INTO mv_base_b VALUES(3,300);
+SELECT * FROM mv_cte ORDER BY i,j;
+ i | j  
+---+----
+ 1 | 10
+ 2 | 20
+ 2 | 20
+ 3 | 30
+ 3 | 30
+ 4 | 40
+(6 rows)
+
+ROLLBACK;
+BEGIN;
+SELECT create_immv('mv_cte',
+    'SELECT * FROM (WITH a AS (SELECT * FROM mv_base_a), b AS ( SELECT * FROM mv_base_b) SELECT a.i,a.j FROM a, b WHERE a.i = b.i) v');
+NOTICE:  could not create an index on immv "mv_cte" automatically
+DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
+HINT:  Create an index on the immv for efficient incremental maintenance.
+ create_immv 
+-------------
+           4
+(1 row)
+
+INSERT INTO mv_base_a VALUES(2,20);
+INSERT INTO mv_base_b VALUES(3,300);
+SELECT * FROM mv_cte ORDER BY i,j;
+ i | j  
+---+----
+ 1 | 10
+ 2 | 20
+ 2 | 20
+ 3 | 30
+ 3 | 30
+ 4 | 40
+(6 rows)
+
+ROLLBACK;
+BEGIN;
+SELECT create_immv('mv_cte',
+    'WITH x AS ( SELECT i, a.j, b.k FROM mv_base_b b INNER JOIN mv_base_a a USING(i)) SELECT * FROM x');
+NOTICE:  could not create an index on immv "mv_cte" automatically
+DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
+HINT:  Create an index on the immv for efficient incremental maintenance.
+ create_immv 
+-------------
+           4
+(1 row)
+
+WITH
+ ai AS (INSERT INTO mv_base_a VALUES (1,11),(2,22) RETURNING 0),
+ bi AS (INSERT INTO mv_base_b VALUES (1,111),(3,133) RETURNING 0),
+ bd AS (DELETE FROM mv_base_b WHERE i = 4 RETURNING 0)
+SELECT;
+--
+(1 row)
+
+SELECT * FROM mv_cte ORDER BY i,j,k;
+ i | j  |  k  
+---+----+-----
+ 1 | 10 | 101
+ 1 | 10 | 111
+ 1 | 11 | 101
+ 1 | 11 | 111
+ 2 | 20 | 102
+ 2 | 22 | 102
+ 3 | 30 | 103
+ 3 | 30 | 133
+(8 rows)
+
+ROLLBACK;
 -- views including NULL
 BEGIN;
 CREATE TABLE base_t (i int, v int);
@@ -920,7 +1054,14 @@ ERROR:  OUTER JOIN is not supported on incrementally maintainable materialized v
 -- CTE is not supported
 SELECT create_immv('mv',
     'WITH b AS ( SELECT * FROM mv_base_b) SELECT a.i,a.j FROM mv_base_a a, b WHERE a.i = b.i;');
-ERROR:  CTE is not supported on incrementally maintainable materialized view
+NOTICE:  could not create an index on immv "mv" automatically
+DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
+HINT:  Create an index on the immv for efficient incremental maintenance.
+ create_immv 
+-------------
+           4
+(1 row)
+
 -- contain system column
 SELECT create_immv('mv_ivm01', 'SELECT i,j,xmin FROM mv_base_a');
 ERROR:  system column is not supported on incrementally maintainable materialized view
@@ -1162,7 +1303,17 @@ SELECT immvrelid, get_immv_def(immvrelid) FROM pg_ivm_immv ORDER BY 1;
            |     b.k                         +
            |    FROM (mv_base_a a            +
            |      JOIN mv_base_b b USING (i))
-(1 row)
+ mv        |  WITH b AS (                    +
+           |          SELECT mv_base_b.i,    +
+           |             mv_base_b.k         +
+           |            FROM mv_base_b       +
+           |         )                       +
+           |  SELECT a.i,                    +
+           |     a.j                         +
+           |    FROM mv_base_a a,            +
+           |     b                           +
+           |   WHERE (a.i = b.i)
+(2 rows)
 
 -- mv_base_b is not immv
 SELECT 'mv_base_b'::regclass, get_immv_def('mv_base_b');
@@ -1172,8 +1323,9 @@ SELECT 'mv_base_b'::regclass, get_immv_def('mv_base_b');
 (1 row)
 
 DROP TABLE mv_base_b CASCADE;
-NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 4 other objects
 DETAIL:  drop cascades to table mv_ivm_1
+drop cascades to table mv
 drop cascades to view b_view
 drop cascades to materialized view b_mview
 DROP TABLE mv_base_a CASCADE;

--- a/expected/pg_ivm.out
+++ b/expected/pg_ivm.out
@@ -740,6 +740,39 @@ SELECT * FROM mv_ivm_join_subquery ORDER BY i,j,k;
 (8 rows)
 
 ROLLBACK;
+BEGIN;
+-- nested subquery
+SELECT create_immv('mv_ivm_join_subquery', 'SELECT i, j, k FROM ( SELECT i, a.j, b.k FROM mv_base_b b INNER JOIN (SELECT * FROM mv_base_a) a USING(i)) tmp');
+NOTICE:  could not create an index on immv "mv_ivm_join_subquery" automatically
+DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
+HINT:  Create an index on the immv for efficient incremental maintenance.
+ create_immv 
+-------------
+           4
+(1 row)
+
+WITH
+ ai AS (INSERT INTO mv_base_a VALUES (1,11),(2,22) RETURNING 0),
+ bi AS (INSERT INTO mv_base_b VALUES (1,111),(3,133) RETURNING 0),
+ bd AS (DELETE FROM mv_base_b WHERE i = 4 RETURNING 0)
+SELECT;
+--
+(1 row)
+
+SELECT * FROM mv_ivm_join_subquery ORDER BY i,j,k;
+ i | j  |  k  
+---+----+-----
+ 1 | 10 | 101
+ 1 | 10 | 111
+ 1 | 11 | 101
+ 1 | 11 | 111
+ 2 | 20 | 102
+ 2 | 22 | 102
+ 3 | 30 | 103
+ 3 | 30 | 133
+(8 rows)
+
+ROLLBACK;
 -- support simple CTE
 BEGIN;
 SELECT create_immv('mv_cte',
@@ -898,12 +931,102 @@ SELECT * FROM mv_cte ORDER BY i,j,k;
  3 | 30 | 133
 (8 rows)
 
-END; -- don't remove for get_immv_def test
+ROLLBACK;
+-- nested CTE 
+BEGIN;
+SELECT create_immv('mv_ivm_nested_cte', 'WITH v AS ( WITH a AS (SELECT * FROM mv_base_a) SELECT i, a.j, b.k FROM mv_base_b b INNER JOIN a USING(i)) SELECT * FROM v');
+NOTICE:  could not create an index on immv "mv_ivm_nested_cte" automatically
+DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
+HINT:  Create an index on the immv for efficient incremental maintenance.
+ create_immv 
+-------------
+           4
+(1 row)
+
+WITH
+ ai AS (INSERT INTO mv_base_a VALUES (1,11),(2,22) RETURNING 0),
+ bi AS (INSERT INTO mv_base_b VALUES (1,111),(3,133) RETURNING 0),
+ bd AS (DELETE FROM mv_base_b WHERE i = 4 RETURNING 0)
+SELECT;
+--
+(1 row)
+
+SELECT * FROM mv_ivm_nested_cte ORDER BY i,j,k;
+ i | j  |  k  
+---+----+-----
+ 1 | 10 | 101
+ 1 | 10 | 111
+ 1 | 11 | 101
+ 1 | 11 | 111
+ 2 | 20 | 102
+ 2 | 22 | 102
+ 3 | 30 | 103
+ 3 | 30 | 133
+(8 rows)
+
+ROLLBACK;
+-- Multiply-referenced CTE
+BEGIN;
+CREATE TABLE base_t (i int, v int);
+INSERT INTO base_t VALUES (1, 10), (2, 20), (3, 30);
+SELECT create_immv('mv_cte_multi(v1, v2)',
+ 'WITH t AS (SELECT * FROM base_t) SELECT t1.v, t2.v FROM t AS t1 JOIN t AS t2 ON t1.i = t2.i');
+NOTICE:  could not create an index on immv "mv_cte_multi" automatically
+DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
+HINT:  Create an index on the immv for efficient incremental maintenance.
+ create_immv 
+-------------
+           3
+(1 row)
+
+SELECT * FROM mv_cte_multi ORDER BY v1;
+ v1 | v2 
+----+----
+ 10 | 10
+ 20 | 20
+ 30 | 30
+(3 rows)
+
+INSERT INTO base_t VALUES (4,40);
+DELETE FROM base_t WHERE i = 1;
+UPDATE base_t SET v = v*10 WHERE i=2;
+SELECT * FROM mv_cte_multi ORDER BY v1;
+ v1  | v2  
+-----+-----
+  30 |  30
+  40 |  40
+ 200 | 200
+(3 rows)
+
+WITH
+ ins_t1 AS (INSERT INTO base_t VALUES (5,50) RETURNING 1),
+ ins_t2 AS (INSERT INTO base_t VALUES (6,60) RETURNING 1),
+ upd_t AS (UPDATE base_t SET v = v + 100  RETURNING 1),
+ dlt_t AS (DELETE FROM base_t WHERE i IN (4,5)  RETURNING 1)
+SELECT NULL;
+ ?column? 
+----------
+ 
+(1 row)
+
+SELECT * FROM mv_cte_multi ORDER BY v1;
+ v1  | v2  
+-----+-----
+  50 |  50
+  60 |  60
+ 130 | 130
+ 300 | 300
+(4 rows)
+
+ROLLBACK;
 --- disallow not-simple CTE
 SELECT create_immv('mv_cte_fail', 'WITH b AS (SELECT i, COUNT(*) FROM mv_base_b GROUP BY i) SELECT a.i,a.j FROM mv_base_a a, b WHERE a.i = b.i');
 ERROR:  aggregate functions in nested query are not supported on incrementally maintainable materialized view
 SELECT create_immv('mv_cte_fail', 'WITH b AS (SELECT DISTINCT i FROM mv_base_b) SELECT a.i,a.j FROM mv_base_a a, b WHERE a.i = b.i');
 ERROR:  DISTINCT clause in nested query are not supported on incrementally maintainable materialized view
+-- unreferenced CTE
+SELECT create_immv('mv_cte_fail', 'WITH b AS (SELECT * FROM mv_base_b) SELECT * FROM mv_base_a a');
+ERROR:  Ureferenced WITH query is not supported on incrementally maintainable materialized view
 -- views including NULL
 BEGIN;
 CREATE TABLE base_t (i int, v int);
@@ -1315,25 +1438,14 @@ TRUNCATE mv_ivm_1;
 ERROR:  cannot change materialized view "mv_ivm_1"
 -- get_immv_def function
 SELECT immvrelid, get_immv_def(immvrelid) FROM pg_ivm_immv ORDER BY 1;
- immvrelid |               get_immv_def               
------------+------------------------------------------
- mv_ivm_1  |  SELECT a.i,                            +
-           |     a.j,                                +
-           |     b.k                                 +
-           |    FROM (mv_base_a a                    +
+ immvrelid |           get_immv_def           
+-----------+----------------------------------
+ mv_ivm_1  |  SELECT a.i,                    +
+           |     a.j,                        +
+           |     b.k                         +
+           |    FROM (mv_base_a a            +
            |      JOIN mv_base_b b USING (i))
- mv_cte    |  WITH x AS (                            +
-           |          SELECT b.i,                    +
-           |             a.j,                        +
-           |             b.k                         +
-           |            FROM (mv_base_b b            +
-           |              JOIN mv_base_a a USING (i))+
-           |         )                               +
-           |  SELECT i,                              +
-           |     j,                                  +
-           |     k                                   +
-           |    FROM x
-(2 rows)
+(1 row)
 
 -- mv_base_b is not immv
 SELECT 'mv_base_b'::regclass, get_immv_def('mv_base_b');
@@ -1343,9 +1455,8 @@ SELECT 'mv_base_b'::regclass, get_immv_def('mv_base_b');
 (1 row)
 
 DROP TABLE mv_base_b CASCADE;
-NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to table mv_ivm_1
-drop cascades to table mv_cte
 drop cascades to view b_view
 drop cascades to materialized view b_mview
 DROP TABLE mv_base_a CASCADE;

--- a/matview.c
+++ b/matview.c
@@ -1128,6 +1128,20 @@ rewrite_query_for_preupdate_state(Query *query, List *tables,
 	/* XXX: Is necessary? Is this right timing? */
 	AcquireRewriteLocks(query, true, false);
 
+	/* convert CTEs to subqueries */
+	foreach (lc, query->cteList)
+	{
+		PlannerInfo root;
+		CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
+
+		if (cte->cterefcount == 0)
+			continue;
+
+		root.parse = query;
+		inline_cte(&root, cte);
+	}
+	query->cteList = NIL;
+
 	i = 1;
 	foreach(lc, query->rtable)
 	{

--- a/pg_ivm.h
+++ b/pg_ivm.h
@@ -15,6 +15,7 @@
 #include "catalog/objectaddress.h"
 #include "fmgr.h"
 #include "nodes/params.h"
+#include "nodes/pathnodes.h"
 #include "parser/parse_node.h"
 #include "tcop/dest.h"
 #include "utils/queryenvironment.h"
@@ -58,5 +59,8 @@ extern bool isIvmName(const char *s);
 /* ruleutils.c */
 
 extern char *pg_ivm_get_viewdef(Relation immvrel, bool pretty);
+
+/* subselect.c */
+extern void inline_cte(PlannerInfo *root, CommonTableExpr *cte);
 
 #endif

--- a/sql/pg_ivm.sql
+++ b/sql/pg_ivm.sql
@@ -233,7 +233,6 @@ SELECT create_immv('mv_ivm_subquery', 'SELECT a.i,a.j FROM mv_base_a a,( SELECT 
 INSERT INTO mv_base_a VALUES(2,20);
 INSERT INTO mv_base_b VALUES(3,300);
 SELECT * FROM mv_ivm_subquery ORDER BY i,j;
-
 ROLLBACK;
 
 -- disallow non-simple subqueries
@@ -254,7 +253,17 @@ WITH
  bd AS (DELETE FROM mv_base_b WHERE i = 4 RETURNING 0)
 SELECT;
 SELECT * FROM mv_ivm_join_subquery ORDER BY i,j,k;
+ROLLBACK;
+BEGIN;
 
+-- nested subquery
+SELECT create_immv('mv_ivm_join_subquery', 'SELECT i, j, k FROM ( SELECT i, a.j, b.k FROM mv_base_b b INNER JOIN (SELECT * FROM mv_base_a) a USING(i)) tmp');
+WITH
+ ai AS (INSERT INTO mv_base_a VALUES (1,11),(2,22) RETURNING 0),
+ bi AS (INSERT INTO mv_base_b VALUES (1,111),(3,133) RETURNING 0),
+ bd AS (DELETE FROM mv_base_b WHERE i = 4 RETURNING 0)
+SELECT;
+SELECT * FROM mv_ivm_join_subquery ORDER BY i,j,k;
 ROLLBACK;
 
 -- support simple CTE
@@ -307,11 +316,45 @@ WITH
  bd AS (DELETE FROM mv_base_b WHERE i = 4 RETURNING 0)
 SELECT;
 SELECT * FROM mv_cte ORDER BY i,j,k;
-END; -- don't remove for get_immv_def test
+ROLLBACK;
+
+-- nested CTE 
+BEGIN;
+SELECT create_immv('mv_ivm_nested_cte', 'WITH v AS ( WITH a AS (SELECT * FROM mv_base_a) SELECT i, a.j, b.k FROM mv_base_b b INNER JOIN a USING(i)) SELECT * FROM v');
+WITH
+ ai AS (INSERT INTO mv_base_a VALUES (1,11),(2,22) RETURNING 0),
+ bi AS (INSERT INTO mv_base_b VALUES (1,111),(3,133) RETURNING 0),
+ bd AS (DELETE FROM mv_base_b WHERE i = 4 RETURNING 0)
+SELECT;
+SELECT * FROM mv_ivm_nested_cte ORDER BY i,j,k;
+ROLLBACK;
+
+-- Multiply-referenced CTE
+BEGIN;
+CREATE TABLE base_t (i int, v int);
+INSERT INTO base_t VALUES (1, 10), (2, 20), (3, 30);
+SELECT create_immv('mv_cte_multi(v1, v2)',
+ 'WITH t AS (SELECT * FROM base_t) SELECT t1.v, t2.v FROM t AS t1 JOIN t AS t2 ON t1.i = t2.i');
+SELECT * FROM mv_cte_multi ORDER BY v1;
+INSERT INTO base_t VALUES (4,40);
+DELETE FROM base_t WHERE i = 1;
+UPDATE base_t SET v = v*10 WHERE i=2;
+SELECT * FROM mv_cte_multi ORDER BY v1;
+WITH
+ ins_t1 AS (INSERT INTO base_t VALUES (5,50) RETURNING 1),
+ ins_t2 AS (INSERT INTO base_t VALUES (6,60) RETURNING 1),
+ upd_t AS (UPDATE base_t SET v = v + 100  RETURNING 1),
+ dlt_t AS (DELETE FROM base_t WHERE i IN (4,5)  RETURNING 1)
+SELECT NULL;
+SELECT * FROM mv_cte_multi ORDER BY v1;
+ROLLBACK;
 
 --- disallow not-simple CTE
 SELECT create_immv('mv_cte_fail', 'WITH b AS (SELECT i, COUNT(*) FROM mv_base_b GROUP BY i) SELECT a.i,a.j FROM mv_base_a a, b WHERE a.i = b.i');
 SELECT create_immv('mv_cte_fail', 'WITH b AS (SELECT DISTINCT i FROM mv_base_b) SELECT a.i,a.j FROM mv_base_a a, b WHERE a.i = b.i');
+
+-- unreferenced CTE
+SELECT create_immv('mv_cte_fail', 'WITH b AS (SELECT * FROM mv_base_b) SELECT * FROM mv_base_a a');
 
 -- views including NULL
 BEGIN;

--- a/subselect.c
+++ b/subselect.c
@@ -1,0 +1,112 @@
+/*-------------------------------------------------------------------------
+ *
+ * subselect.c
+ *	  incremental view maintenance extension
+ *	  Routines for CTE support.
+ *
+ * Portions Copyright (c) 2023, IVM Development Group
+ * Portions Copyright (c) 1996-2022, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "nodes/nodeFuncs.h"
+#include "rewrite/rewriteManip.h"
+
+#include "pg_ivm.h"
+
+typedef struct inline_cte_walker_context
+{
+	const char *ctename;		/* name and relative level of target CTE */
+	int			levelsup;
+	Query	   *ctequery;		/* query to substitute */
+} inline_cte_walker_context;
+
+static bool inline_cte_walker(Node *node, inline_cte_walker_context *context);
+
+/*
+ * inline_cte: convert RTE_CTE references to given CTE into RTE_SUBQUERYs
+ */
+void
+inline_cte(PlannerInfo *root, CommonTableExpr *cte)
+{
+	struct inline_cte_walker_context context;
+
+	context.ctename = cte->ctename;
+	/* Start at levelsup = -1 because we'll immediately increment it */
+	context.levelsup = -1;
+	context.ctequery = castNode(Query, cte->ctequery);
+
+	(void) inline_cte_walker((Node *) root->parse, &context);
+}
+
+static bool
+inline_cte_walker(Node *node, inline_cte_walker_context *context)
+{
+	if (node == NULL)
+		return false;
+	if (IsA(node, Query))
+	{
+		Query	   *query = (Query *) node;
+
+		context->levelsup++;
+
+		/*
+		 * Visit the query's RTE nodes after their contents; otherwise
+		 * query_tree_walker would descend into the newly inlined CTE query,
+		 * which we don't want.
+		 */
+		(void) query_tree_walker(query, inline_cte_walker, context,
+								 QTW_EXAMINE_RTES_AFTER);
+
+		context->levelsup--;
+
+		return false;
+	}
+	else if (IsA(node, RangeTblEntry))
+	{
+		RangeTblEntry *rte = (RangeTblEntry *) node;
+
+		if (rte->rtekind == RTE_CTE &&
+			strcmp(rte->ctename, context->ctename) == 0 &&
+			rte->ctelevelsup == context->levelsup)
+		{
+			/*
+			 * Found a reference to replace.  Generate a copy of the CTE query
+			 * with appropriate level adjustment for outer references (e.g.,
+			 * to other CTEs).
+			 */
+			Query	   *newquery = copyObject(context->ctequery);
+
+			if (context->levelsup > 0)
+				IncrementVarSublevelsUp((Node *) newquery, context->levelsup, 1);
+
+			/*
+			 * Convert the RTE_CTE RTE into a RTE_SUBQUERY.
+			 *
+			 * Historically, a FOR UPDATE clause has been treated as extending
+			 * into views and subqueries, but not into CTEs.  We preserve this
+			 * distinction by not trying to push rowmarks into the new
+			 * subquery.
+			 */
+			rte->rtekind = RTE_SUBQUERY;
+			rte->subquery = newquery;
+			rte->security_barrier = false;
+
+			/* Zero out CTE-specific fields */
+			rte->ctename = NULL;
+			rte->ctelevelsup = 0;
+			rte->self_reference = false;
+			rte->coltypes = NIL;
+			rte->coltypmods = NIL;
+			rte->colcollations = NIL;
+		}
+
+		return false;
+	}
+
+	return expression_tree_walker(node, inline_cte_walker, context);
+}


### PR DESCRIPTION
Simple CTEs which does not contain aggregates or DISTINCT are now supported similarly to simple sub-queries.

Before a view is maintained, all CTEs are converted to corresponding subqueries to enable to treat CTEs as same as subqueries. For this end, codes of the static fnction inline_cte in the core (optimizer/plan/subselect.c) was imported.