### PR TITLE
Prohibit types without default btree opclass in the target list

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,10 @@ Currently, IMMV's view definition can contain inner joins, DISTINCT clause, some
 
 The base tables must be simple tables. Views, materialized views, inheritance parent tables, partitioned tables, partitions, and foreign tables can not be used.
 
-The targetlist cannot contain system columns, columns whose name starts with `__ivm_`.
+Any system column cannot be included in the view definition query.
+The target list cannot columns whose name starts with `__ivm_`.
+
+Data type used in the target list in the view must have default operator class for access method btree. For example, `json`, `xml`, or `point` type cannot be in the target list.
 
 Logical replication is not supported, that is, even when a base table at a publisher node is modified, IMMVs at subscriber nodes defined on these base tables are not updated.
 

--- a/expected/pg_ivm.out
+++ b/expected/pg_ivm.out
@@ -1636,6 +1636,12 @@ NOTICE:  created index "mv_idx6_index" on immv "mv_idx6"
 (1 row)
 
 ROLLBACK;
+-- type that doesn't have default operator class for access method btree
+BEGIN;
+CREATE TABLE table_json (j json);
+SELECT create_immv('mv_json', 'SELECT * from table_json');
+ERROR:  data type json has no default operator class for access method "btree"
+ROLLBACK;
 -- prevent IMMV chanages
 INSERT INTO mv_ivm_1 VALUES(1,1,1);
 ERROR:  cannot change materialized view "mv_ivm_1"

--- a/sql/pg_ivm.sql
+++ b/sql/pg_ivm.sql
@@ -658,6 +658,12 @@ SELECT create_immv('mv_idx5', 'SELECT a.i, b.j FROM base_a a, base_b b');
 SELECT create_immv('mv_idx6(i_a, i_b)', 'SELECT a.i, b.i FROM (SELECT * FROM base_a) a, (SELECT * FROM base_b) b');
 ROLLBACK;
 
+-- type that doesn't have default operator class for access method btree
+BEGIN;
+CREATE TABLE table_json (j json);
+SELECT create_immv('mv_json', 'SELECT * from table_json');
+ROLLBACK;
+
 -- prevent IMMV chanages
 INSERT INTO mv_ivm_1 VALUES(1,1,1);
 UPDATE  mv_ivm_1 SET k = 1 WHERE i = 1;


### PR DESCRIPTION
Currently, types that does not have an equality operator cannot be used in the target list of the view definition, because all of target list entries are used for comparison to identify rows to be updated or deleted in the view. Previously, an error is raised at the time such view is incrementally maintained, this is fixed to check that at the view creation time.

This restriction may be relaxed in future after we can use an index to identify rows in the view.

Issue #61