### PR TITLE
Add support for PostgreSQL 16 (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The `pg_ivm` module provides Incremental View Maintenance (IVM) feature for PostgreSQL.
 
-The extension is compatible with PostgreSQL 13, 14, and 15.
+The extension is compatible with PostgreSQL 13, 14, 15, and 16.
 
 ## Description
 

--- a/matview.c
+++ b/matview.c
@@ -354,9 +354,6 @@ ExecRefreshImmv(const RangeVar *relation, bool skipData,
 	{
 		Relation	tgRel;
 		Relation	depRel;
-		ScanKeyData key;
-		SysScanDesc scan;
-		HeapTuple	tup;
 		ObjectAddresses *immv_triggers;
 
 		immv_triggers = new_object_addresses();
@@ -450,7 +447,7 @@ ExecRefreshImmv(const RangeVar *relation, bool skipData,
 		pgstat_count_heap_insert(matviewRel, processed);
 
 	if (!skipData && !oldPopulated)
-		CreateIvmTriggersOnBaseTables(viewQuery, matviewOid, true);
+		CreateIvmTriggersOnBaseTables(viewQuery, matviewOid);
 
 	table_close(matviewRel, NoLock);
 
@@ -905,8 +902,13 @@ IVM_immediate_maintenance(PG_FUNCTION_ARGS)
 		if (!(query->hasAggs && query->groupClause == NIL))
 		{
 			OpenImmvIncrementalMaintenance();
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 160000)
+			ExecuteTruncateGuts(list_make1(matviewRel), list_make1_oid(matviewOid),
+								NIL, DROP_RESTRICT, false, false);
+#else
 			ExecuteTruncateGuts(list_make1(matviewRel), list_make1_oid(matviewOid),
 								NIL, DROP_RESTRICT, false);
+#endif
 			CloseImmvIncrementalMaintenance();
 		}
 		else
@@ -1041,7 +1043,6 @@ IVM_immediate_maintenance(PG_FUNCTION_ARGS)
 		foreach(lc2, table->rte_paths)
 		{
 			List	*rte_path = lfirst(lc2);
-			int i;
 			Query *querytree = rewritten;
 			RangeTblEntry  *rte;
 			TupleDesc		tupdesc_old;
@@ -1050,9 +1051,9 @@ IVM_immediate_maintenance(PG_FUNCTION_ARGS)
 			char   *count_colname = NULL;
 
 			/* check if the modified table is in EXISTS clause. */
-			for (i = 0; i < list_length(rte_path); i++)
+			for (int j = 0; j < list_length(rte_path); j++)
 			{
-				int index =  lfirst_int(list_nth_cell(rte_path, i));
+				int index =  lfirst_int(list_nth_cell(rte_path, j));
 				rte = (RangeTblEntry *) lfirst(list_nth_cell(querytree->rtable, index - 1));
 
 				if (rte != NULL && rte->rtekind == RTE_SUBQUERY)
@@ -1359,7 +1360,7 @@ get_prestate_rte(RangeTblEntry *rte, MV_TriggerTable *table,
 {
 	StringInfoData str;
 	RawStmt *raw;
-	Query *sub;
+	Query *subquery;
 	Relation rel;
 	ParseState *pstate;
 	char *relname;
@@ -1371,7 +1372,7 @@ get_prestate_rte(RangeTblEntry *rte, MV_TriggerTable *table,
 
 	/*
 	 * We can use NoLock here since AcquireRewriteLocks should
-	 * have locked the rel already.
+	 * have locked the relation already.
 	 */
 	rel = table_open(table->table_id, NoLock);
 	relname = quote_qualified_identifier(
@@ -1379,12 +1380,19 @@ get_prestate_rte(RangeTblEntry *rte, MV_TriggerTable *table,
 									   RelationGetRelationName(rel));
 	table_close(rel, NoLock);
 
+	/*
+	 * Filtering inserted row using the snapshot taken before the table
+	 * is modified. ctid is required for maintaining outer join views.
+	 */
 	initStringInfo(&str);
 	appendStringInfo(&str,
 		"SELECT t.* FROM %s t"
 		" WHERE pg_catalog.ivm_visible_in_prestate(t.tableoid, t.ctid ,%d::pg_catalog.oid)",
 			relname, matviewid);
 
+	/*
+	 * Append deleted rows contained in old transition tables.
+	 */
 	for (i = 0; i < list_length(table->old_tuplestores); i++)
 	{
 		appendStringInfo(&str, " UNION ALL ");
@@ -1392,20 +1400,21 @@ get_prestate_rte(RangeTblEntry *rte, MV_TriggerTable *table,
 			make_delta_enr_name("old", table->table_id, i));
 	}
 
-
+	/* Get a subquery representing pre-state of the table */
 #if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 140000)
 	raw = (RawStmt*)linitial(raw_parser(str.data, RAW_PARSE_DEFAULT));
 #else
 	raw = (RawStmt*)linitial(raw_parser(str.data));
 #endif
-	sub = transformStmt(pstate, raw->stmt);
+	subquery = transformStmt(pstate, raw->stmt);
 
 	/* save the original RTE */
 	table->original_rte = copyObject(rte);
 
 	rte->rtekind = RTE_SUBQUERY;
-	rte->subquery = sub;
+	rte->subquery = subquery;
 	rte->security_barrier = false;
+
 	/* Clear fields that should not be set in a subquery RTE */
 	rte->relid = InvalidOid;
 	rte->relkind = 0;
@@ -1413,12 +1422,16 @@ get_prestate_rte(RangeTblEntry *rte, MV_TriggerTable *table,
 	rte->tablesample = NULL;
 	rte->inh = false;			/* must not be set for a subquery */
 
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 160000)
+	rte->perminfoindex = 0;         /* no permission checking for this RTE */
+#else
 	rte->requiredPerms = 0;		/* no permission check on subquery itself */
 	rte->checkAsUser = InvalidOid;
 	rte->selectedCols = NULL;
 	rte->insertedCols = NULL;
 	rte->updatedCols = NULL;
 	rte->extraUpdatedCols = NULL;
+#endif
 
 	return rte;
 }

--- a/matview.c
+++ b/matview.c
@@ -1051,9 +1051,9 @@ IVM_immediate_maintenance(PG_FUNCTION_ARGS)
 			char   *count_colname = NULL;
 
 			/* check if the modified table is in EXISTS clause. */
-			for (int j = 0; j < list_length(rte_path); j++)
+			for (i = 0; i < list_length(rte_path); i++)
 			{
-				int index =  lfirst_int(list_nth_cell(rte_path, j));
+				int index =  lfirst_int(list_nth_cell(rte_path, i));
 				rte = (RangeTblEntry *) lfirst(list_nth_cell(querytree->rtable, index - 1));
 
 				if (rte != NULL && rte->rtekind == RTE_SUBQUERY)

--- a/pg_ivm.c
+++ b/pg_ivm.c
@@ -122,7 +122,11 @@ parseNameAndColumns(const char *string, List **names, List **colNames)
 
 	/* Separate the name and parse it into a list */
 	*ptr++ = '\0';
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 160000)
+	*names = stringToQualifiedNameList(rawname, NULL);
+#else
 	*names = stringToQualifiedNameList(rawname);
+#endif
 
 	if (!has_colnames)
 		goto end;

--- a/pg_ivm.h
+++ b/pg_ivm.h
@@ -38,8 +38,8 @@ extern bool isImmv(Oid immv_oid);
 extern ObjectAddress ExecCreateImmv(ParseState *pstate, CreateTableAsStmt *stmt,
 									ParamListInfo params, QueryEnvironment *queryEnv,
 									QueryCompletion *qc);
-extern void CreateIvmTriggersOnBaseTables(Query *qry, Oid matviewOid, bool is_create);
-extern void CreateIndexOnIMMV(Query *query, Relation matviewRel, bool is_create);
+extern void CreateIvmTriggersOnBaseTables(Query *qry, Oid matviewOid);
+extern void CreateIndexOnIMMV(Query *query, Relation matviewRel);
 extern Query *rewriteQueryForIMMV(Query *query, List *colNames);
 extern void makeIvmAggColumn(ParseState *pstate, Aggref *aggref, char *resname, AttrNumber *next_resno, List **aggs);
 


### PR DESCRIPTION
Build errors/warnings against PostgreSQL 16 are fixed. Also, adapted to the change of codes, including:

- Get rid of the "new" and "old" entries in a view's rangetable. (Althogh, removed codes were dead codes because pg_ivm doesn't
 have any rules in pg_rewrite.)

- Rework query relation permission checking

- Require empty Bitmapsets to be represented as NULL