### PR TITLE
Check if PgIvmImmvRelationId is invalid before open it

### DIFF
--- a/pg_ivm.c
+++ b/pg_ivm.c
@@ -385,11 +385,16 @@ PgIvmObjectAccessHook(ObjectAccessType access, Oid classId,
 
 	if (access == OAT_DROP && classId == RelationRelationId && !OidIsValid(subId))
 	{
-		Relation pgIvmImmv = table_open(PgIvmImmvRelationId(), AccessShareLock);
+		Relation pgIvmImmv;
 		SysScanDesc scan;
 		ScanKeyData key;
 		HeapTuple tup;
-
+		Oid pgIvmImmvOid = PgIvmImmvRelationId();
+		
+		if (pgIvmImmvOid == InvalidOid)
+			return;
+		
+		pgIvmImmv = table_open(pgIvmImmvOid, AccessShareLock);
 		ScanKeyInit(&key,
 					Anum_pg_ivm_immv_immvrelid,
 					BTEqualStrategyNumber, F_OIDEQ,


### PR DESCRIPTION
#77 Fix the problem that preloaded pg_ivm will break Postgresql's regression tests.

I don't know exactly why PgIvmImmvRelationId() will return an invalidOid, but checking if it is will help fix this problem.