### PR TITLE
Fix typo in README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ When `pg_ivm` is installed, the following objects are created.
 
 ### Functions
 
-#### create_imm
+#### create_immv
 
 Use `create_immv` function to create IMMV.
 ```


### PR DESCRIPTION
This trivial Pull Request fixes a typo in the heading of the documentation describing the `create_immv()` function.