### PR TITLE
Add support for PostgreSQL 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The `pg_ivm` module provides Incremental View Maintenance (IVM) feature for PostgreSQL.
 
-The extension is compatible with PostgreSQL 13, 14, 15, and 16.
+The extension is compatible with PostgreSQL 13, 14, 15, 16, and 17.
 
 ## Description
 
@@ -54,6 +54,8 @@ postgres=# SELECT * FROM m; -- automatically updated
 (4 rows)
 ```
 
+Note that if you use PostgreSQL 17 or later, during automatic maintenance of an IMMV, the `search_path` is temporarily changed to `pg_catalog, pg_temp`.
+
 ## Installation
 To install `pg_ivm`, execute this in the module's directory:
 
@@ -97,9 +99,11 @@ Use `refresh_immv` function to refresh IMMV.
 refresh_immv(immv_name text, with_data bool) RETURNS bigint
 ```
 
-`refresh_immv` completely replaces the contents of an IMMV as `REFRESH MATERIALIZED VIEW` command does for a materialized view. To execute this function you must be the owner of the IMMV.  The old contents are discarded.
+`refresh_immv` completely replaces the contents of an IMMV as `REFRESH MATERIALIZED VIEW` command does for a materialized view. To execute this function you must be the owner of the IMMV (with PostgreSQL 16 or earlier) or have the `MAINTAIN` privilege on the IMMV (with PostgreSQL 17 or later).  The old contents are discarded.
 
 The with_data flag is corresponding to `WITH [NO] DATA` option of REFRESH MATERIALIZED VIEW` command. If with_data is true, the backing query is executed to provide the new data, and if the IMMV is unpopulated, triggers for maintaining the view are created. Also, a unique index is created for IMMV if it is possible and the view doesn't have that yet. If with_data is false, no new data is generated and the IMMV become unpopulated, and the triggers are dropped from the IMMV. Note that unpopulated IMMV is still scannable although the result is empty. This behaviour may be changed in future to raise an error when an unpopulated IMMV is scanned.
+
+Note that if you use PostgreSQL 17 or later, while `refresh_immv` is running, the `search_path` is temporarily changed to `pg_catalog, pg_temp`.
 
 #### get_immv_def
 

--- a/pg_ivm.h
+++ b/pg_ivm.h
@@ -48,6 +48,8 @@ extern void makeIvmAggColumn(ParseState *pstate, Aggref *aggref, char *resname, 
 extern Query *get_immv_query(Relation matviewRel);
 extern ObjectAddress ExecRefreshImmv(const RangeVar *relation, bool skipData,
 									 const char *queryString, QueryCompletion *qc);
+extern ObjectAddress RefreshImmvByOid(Oid matviewOid, bool skipData,
+									  const char *queryString, QueryCompletion *qc);
 extern bool ImmvIncrementalMaintenanceIsEnabled(void);
 extern Query *get_immv_query(Relation matviewRel);
 extern Datum IVM_immediate_before(PG_FUNCTION_ARGS);


### PR DESCRIPTION
Compilation errors and warning are fixed.

The design of create_immv is also chaned as similar to PG17, that is, firstly a relation is created without data then it is populated by using the refresh logic.

This commit contains the following changes:

 - Change functions to use a safe search_path during maintenance operations when used with PostgreSQL 17

  This prevents maintenance operations (automatic maintenance of IMMVs and
  refresh_immv) from performing unsafe access.  Functions used by IMMVs that
  need to reference non-default schemas must specify a search path during
  function creation.

 - refresh_immv can be executed by users with the MAINTAIN privilege when used with PostgreSQL 17

Issue #90