### PR TITLE
WIP: Allow partitioned tables in IMMVs

### DIFF
--- a/createas.c
+++ b/createas.c
@@ -897,10 +897,6 @@ check_ivm_restriction_walker(Node *node, check_ivm_restriction_context *context)
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								 errmsg("TABLESAMPLE clause is not supported on incrementally maintainable materialized view")));
 
-					if (rte->relkind == RELKIND_PARTITIONED_TABLE)
-						ereport(ERROR,
-								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								 errmsg("partitioned table is not supported on incrementally maintainable materialized view")));
 
 					if (rte->relkind == RELKIND_RELATION && has_superclass(rte->relid))
 						ereport(ERROR,

--- a/expected/refresh_immv.out
+++ b/expected/refresh_immv.out
@@ -116,3 +116,33 @@ ERROR:  relation "mv_not_existing" does not exist
 -- Try to refresh a normal table -- error
 SELECT refresh_immv('t', true);
 ERROR:  "t" is not an IMMV
+-- Create partitioned table
+CREATE TABLE foo (id integer) PARTITION BY RANGE(id);
+CREATE TABLE foo_default PARTITION OF foo DEFAULT;
+INSERT INTO foo VALUES (1), (2), (3);
+SELECT create_immv('foo_mv', 'SELECT COUNT(*) as count FROM foo');
+ create_immv 
+-------------
+           1
+(1 row)
+
+SELECT count FROM foo_mv;
+ count 
+-------
+     3
+(1 row)
+
+ALTER TABLE foo DETACH PARTITION foo_default;
+SELECT count FROM foo_mv;
+ count 
+-------
+     0
+(1 row)
+
+ALTER TABLE foo ATTACH PARTITION foo_default DEFAULT;
+SELECT count FROM foo_mv;
+ count 
+-------
+     3
+(1 row)
+

--- a/pg_ivm--1.0.sql
+++ b/pg_ivm--1.0.sql
@@ -17,8 +17,22 @@ SELECT pg_catalog.pg_extension_config_dump('pg_catalog.pg_ivm_immv', '');
 
 -- functions
 
+CREATE FUNCTION changes_partitions(pg_ddl_command)
+RETURNS boolean
+IMMUTABLE
+STRICT
+AS 'MODULE_PATHNAME', 'changes_partitions'
+LANGUAGE C;
+
+-- CREATE FUNCTION get_command_type(text, text, pg_ddl_command, text)
+-- RETURNS void
+-- IMMUTABLE
+-- STRICT
+-- AS 'MODULE_PATHNAME', 'get_command_type'
+-- LANGUAGE C;
+
 CREATE FUNCTION create_immv(text, text)
-RETURNS bigint 
+RETURNS bigint
 STRICT
 AS 'MODULE_PATHNAME', 'create_immv'
 LANGUAGE C;
@@ -26,17 +40,17 @@ LANGUAGE C;
 -- trigger functions
 
 CREATE FUNCTION "IVM_immediate_before"()
-RETURNS trigger 
+RETURNS trigger
 AS 'MODULE_PATHNAME', 'IVM_immediate_before'
 LANGUAGE C;
 
 CREATE FUNCTION "IVM_immediate_maintenance"()
-RETURNS trigger 
+RETURNS trigger
 AS 'MODULE_PATHNAME', 'IVM_immediate_maintenance'
 LANGUAGE C;
 
 CREATE FUNCTION "IVM_prevent_immv_change"()
-RETURNS trigger 
+RETURNS trigger
 AS 'MODULE_PATHNAME', 'IVM_prevent_immv_change'
 LANGUAGE C;
 
@@ -64,3 +78,33 @@ $$ LANGUAGE plpgsql;
 CREATE EVENT TRIGGER pg_ivm_sql_drop_trigger
 ON sql_drop
 EXECUTE PROCEDURE pg_catalog.pg_ivm_sql_drop_trigger_func();
+
+-- Process ALTER TABLE, specifically ATTACH/DETACH PARTITION
+-- TODO: Get incremental update working
+CREATE OR REPLACE FUNCTION ivm_immediate_event()
+ RETURNS event_trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN SELECT * FROM pg_event_trigger_ddl_commands()
+  LOOP
+    IF changes_partitions(r.command) THEN
+      PERFORM refresh_immv(
+        convert_from(
+          substring(tgargs FOR (position('\x00'::bytea in tgargs)-1)),
+          'SQL_ASCII'
+        )::oid::regclass::text,
+        true)
+      FROM pg_trigger
+      WHERE tgfoid='"IVM_immediate_maintenance"'::regproc AND tgtype=4;
+    END IF;
+  END LOOP;
+END;
+$function$;
+
+-- Run on any ALTER TABLE
+CREATE EVENT TRIGGER IVM_trigger_event
+ON ddl_command_end WHEN TAG IN ('ALTER TABLE')
+EXECUTE PROCEDURE ivm_immediate_event();

--- a/pg_ivm.h
+++ b/pg_ivm.h
@@ -52,6 +52,7 @@ extern ObjectAddress RefreshImmvByOid(Oid matviewOid, bool skipData,
 									  const char *queryString, QueryCompletion *qc);
 extern bool ImmvIncrementalMaintenanceIsEnabled(void);
 extern Query *get_immv_query(Relation matviewRel);
+extern Datum changes_partitions(PG_FUNCTION_ARGS);
 extern Datum IVM_immediate_before(PG_FUNCTION_ARGS);
 extern Datum IVM_immediate_maintenance(PG_FUNCTION_ARGS);
 extern Query* rewrite_query_for_exists_subquery(Query *query);

--- a/sql/refresh_immv.sql
+++ b/sql/refresh_immv.sql
@@ -37,3 +37,18 @@ SELECT refresh_immv('mv_not_existing', true);
 
 -- Try to refresh a normal table -- error
 SELECT refresh_immv('t', true);
+
+-- Create partitioned table
+CREATE TABLE foo (id integer) PARTITION BY RANGE(id);
+CREATE TABLE foo_default PARTITION OF foo DEFAULT;
+
+INSERT INTO foo VALUES (1), (2), (3);
+
+SELECT create_immv('foo_mv', 'SELECT COUNT(*) as count FROM foo');
+SELECT count FROM foo_mv;
+
+ALTER TABLE foo DETACH PARTITION foo_default;
+SELECT count FROM foo_mv;
+
+ALTER TABLE foo ATTACH PARTITION foo_default DEFAULT;
+SELECT count FROM foo_mv;


### PR DESCRIPTION
This isn't feature-complete yet, but opening as a place to start a conversation around how to fully implement this feature.

At the moment, the prohibition on partitioned tables is removed, and hooks are added to handle `ATTACH PARTITION` and `DETACH PARTITION`.

To do:

  * Add check to prohibit multiple partitioned tables (causes crash)
  * Change ATTACH/DETACH to be incremental (presently does a REFRESH)
  * Figure out issue with multiple tables and correct it