### PR TITLE
Drop unused params from ExecCreateImmv function

### DIFF
--- a/createas.c
+++ b/createas.c
@@ -234,7 +234,6 @@ create_immv_nodata(List *tlist, IntoClause *into)
  */
 ObjectAddress
 ExecCreateImmv(ParseState *pstate, CreateTableAsStmt *stmt,
-				  ParamListInfo params, QueryEnvironment *queryEnv,
 				  QueryCompletion *qc)
 {
 	Query	   *query = castNode(Query, stmt->query);

--- a/pg_ivm.c
+++ b/pg_ivm.c
@@ -228,7 +228,7 @@ create_immv(PG_FUNCTION_ARGS)
 	query = transformStmt(pstate, (Node *)ctas);
 	Assert(query->commandType == CMD_UTILITY && IsA(query->utilityStmt, CreateTableAsStmt));
 
-	ExecCreateImmv(pstate, (CreateTableAsStmt *) query->utilityStmt, NULL, NULL, &qc);
+	ExecCreateImmv(pstate, (CreateTableAsStmt *) query->utilityStmt, &qc);
 
 	PG_RETURN_INT64(qc.nprocessed);
 }

--- a/pg_ivm.h
+++ b/pg_ivm.h
@@ -36,7 +36,6 @@ extern bool isImmv(Oid immv_oid);
 /* createas.c */
 
 extern ObjectAddress ExecCreateImmv(ParseState *pstate, CreateTableAsStmt *stmt,
-									ParamListInfo params, QueryEnvironment *queryEnv,
 									QueryCompletion *qc);
 extern void CreateIvmTriggersOnBaseTables(Query *qry, Oid matviewOid);
 extern void CreateIndexOnIMMV(Query *query, Relation matviewRel);


### PR DESCRIPTION
Hi! while adapting this extension for Greenplum I happened to notice that ExecCreateImmv func accept params that does not have any use. 
SO I propose a small refactoring. This reduce maintenance pain for Greenplum. 