### PR TITLE
Prevent automatic index creation with set-returning function

### DIFF
--- a/expected/pg_ivm.out
+++ b/expected/pg_ivm.out
@@ -1663,9 +1663,19 @@ HINT:  Create an index on the immv for efficient incremental maintenance.
            0
 (1 row)
 
---- subqueries
+--- subqueries: create an index
 SELECT create_immv('mv_idx6(i_a, i_b)', 'SELECT a.i, b.i FROM (SELECT * FROM base_a) a, (SELECT * FROM base_b) b');
 NOTICE:  created index "mv_idx6_index" on immv "mv_idx6"
+ create_immv 
+-------------
+           0
+(1 row)
+
+--- with set-returning function: no index
+SELECT create_immv('mv_idx7', 'SELECT i FROM base_a, generate_series(1,10)');
+NOTICE:  could not create an index on immv "mv_idx7" automatically
+DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
+HINT:  Create an index on the immv for efficient incremental maintenance.
  create_immv 
 -------------
            0

--- a/sql/pg_ivm.sql
+++ b/sql/pg_ivm.sql
@@ -662,8 +662,12 @@ SELECT create_immv('mv_idx3(i_a, i_b)', 'SELECT a.i, b.i FROM base_a a, base_b b
 SELECT create_immv('mv_idx4', 'SELECT j FROM base_a');
 SELECT create_immv('mv_idx5', 'SELECT a.i, b.j FROM base_a a, base_b b');
 
---- subqueries
+--- subqueries: create an index
 SELECT create_immv('mv_idx6(i_a, i_b)', 'SELECT a.i, b.i FROM (SELECT * FROM base_a) a, (SELECT * FROM base_b) b');
+
+--- with set-returning function: no index
+SELECT create_immv('mv_idx7', 'SELECT i FROM base_a, generate_series(1,10)');
+
 ROLLBACK;
 
 -- type that doesn't have default operator class for access method btree


### PR DESCRIPTION
Previously, a unique index is automatically created even when a set-returning function is contained in FROM clause, but this results in an error due to key duplication. Now, an index is not created automatically when a relation other than table, sub-query, or join is contained in FROM clause.

Issue (#99)