### PR TITLE
Fix targetlist of subquery substituting modified table

### DIFF
--- a/expected/pg_ivm.out
+++ b/expected/pg_ivm.out
@@ -1,14 +1,19 @@
 CREATE EXTENSION pg_ivm;
 GRANT ALL ON SCHEMA public TO public;
 -- create a table to use as a basis for views and materialized views in various combinations
-CREATE TABLE mv_base_a (i int, j int);
+CREATE TABLE mv_base_a (x int, i int, y int, j int);
+CREATE TABLE mv_base_b (x int, i int, y int, k int);
+-- test for base tables with dropped columns
+ALTER TABLE mv_base_a DROP COLUMN x;
+ALTER TABLE mv_base_a DROP COLUMN y;
+ALTER TABLE mv_base_b DROP COLUMN x;
+ALTER TABLE mv_base_b DROP COLUMN y;
 INSERT INTO mv_base_a VALUES
   (1,10),
   (2,20),
   (3,30),
   (4,40),
   (5,50);
-CREATE TABLE mv_base_b (i int, k int);
 INSERT INTO mv_base_b VALUES
   (1,101),
   (2,102),

--- a/sql/pg_ivm.sql
+++ b/sql/pg_ivm.sql
@@ -2,14 +2,21 @@ CREATE EXTENSION pg_ivm;
 GRANT ALL ON SCHEMA public TO public;
 
 -- create a table to use as a basis for views and materialized views in various combinations
-CREATE TABLE mv_base_a (i int, j int);
+CREATE TABLE mv_base_a (x int, i int, y int, j int);
+CREATE TABLE mv_base_b (x int, i int, y int, k int);
+
+-- test for base tables with dropped columns
+ALTER TABLE mv_base_a DROP COLUMN x;
+ALTER TABLE mv_base_a DROP COLUMN y;
+ALTER TABLE mv_base_b DROP COLUMN x;
+ALTER TABLE mv_base_b DROP COLUMN y;
+
 INSERT INTO mv_base_a VALUES
   (1,10),
   (2,20),
   (3,30),
   (4,40),
   (5,50);
-CREATE TABLE mv_base_b (i int, k int);
 INSERT INTO mv_base_b VALUES
   (1,101),
   (2,102),


### PR DESCRIPTION
A RTE of modified table in the view definition query is substituted by a subquery representing a delta table or a pre-update state table during view maintenance. After this rewrite, Var that used to reference the table column should become to references the corresponding column in the subquery targetlist. Previously, the targetlist contained only existing columns of the table. This was not a problem as long as the table didn't have any dropped column because varattnos in the query tree  was identical to resno of the targetlist. However, if the table has a dropped column, we cannot assume this correspondence, so an error like the following occurred in that situation.

ERROR: could not find attribute 43 in subquery targetlist

To fix it,  put "null" as a dummy value at the position in the targetlist of a dropped column so that varattnos in the query tree is identical to resno of the targetlist. We would also able to fix this by walking the query tree to rewrite varattnos, but crafting targetlist is more simple and reasonable.

Issue #85