### PR TITLE
Update schema to pgivm in control file

### DIFF
--- a/pg_ivm--1.10.sql
+++ b/pg_ivm--1.10.sql
@@ -1,5 +1,3 @@
-CREATE SCHEMA pgivm;
-
 -- catalog
 
 CREATE TABLE pgivm.pg_ivm_immv(

--- a/pg_ivm.control
+++ b/pg_ivm.control
@@ -3,4 +3,4 @@ comment = 'incremental view maintenance on PostgreSQL'
 default_version = '1.10'
 module_pathname = '$libdir/pg_ivm'
 relocatable = false 
-schema = pg_catalog
+schema = pgivm


### PR DESCRIPTION
Hi, I noticed that the extension control file still says `schema = pg_catalog` even though the schema is now `pgivm`. I updated the control file to reflect the new schema.

Since Postgres automatically creates the schema specified in the control file, I removed the `CREATE SCHEMA pgivm` line from `pg_ivm--1.10.sql`.

For any users upgrading from 1.9 to 1.10, Postgres does not change the extension metadata unless the extension is dropped and re-created from my testing. So we still need the `CREATE SCHEMA pgivm` line in `pg_ivm--1.9--1.10.sql`.