### PR TITLE
Store and maintain the SQL query string in pg_ivm_immv.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ DATA = pg_ivm--1.0.sql \
        pg_ivm--1.3--1.4.sql pg_ivm--1.4--1.5.sql pg_ivm--1.5--1.6.sql \
        pg_ivm--1.6--1.7.sql pg_ivm--1.7--1.8.sql pg_ivm--1.8--1.9.sql \
        pg_ivm--1.9--1.10.sql \
-	   pg_ivm--1.10.sql
+	   pg_ivm--1.10.sql pg_ivm--1.10--1.11.sql
 
 REGRESS = pg_ivm create_immv refresh_immv
 

--- a/createas.c
+++ b/createas.c
@@ -1719,6 +1719,7 @@ StoreImmvQuery(Oid viewOid, Query *viewQuery)
 
 	memset(values, 0, sizeof(values));
 	memset(isNulls, false, sizeof(isNulls));
+	isNulls[Anum_pg_ivm_immv_querystring - 1] = true;
 
 	values[Anum_pg_ivm_immv_immvrelid -1 ] = ObjectIdGetDatum(viewOid);
 	values[Anum_pg_ivm_immv_ispopulated -1 ] = BoolGetDatum(false);

--- a/matview.c
+++ b/matview.c
@@ -444,7 +444,8 @@ RefreshImmvByOid(Oid matviewOid, bool is_create, bool skipData,
 				tgform = (Form_pg_trigger) GETSTRUCT(tgtup);
 
 				/* If trigger is created by IMMV, delete it. */
-				if (strncmp(NameStr(tgform->tgname), "IVM_trigger_", 12) == 0)
+				if (strncmp(NameStr(tgform->tgname), "IVM_trigger_", 12) == 0 ||
+					strncmp(NameStr(tgform->tgname), "IVM_prevent_", 12) == 0)
 				{
 					obj.classId = foundDep->classid;
 					obj.objectId = foundDep->objid;
@@ -474,7 +475,10 @@ RefreshImmvByOid(Oid matviewOid, bool is_create, bool skipData,
 	 * is created.
 	 */
 	if (!skipData && !oldPopulated)
+	{
 		CreateIvmTriggersOnBaseTables(dataQuery, matviewOid);
+		CreateChangePreventTrigger(matviewOid);
+	}
 
 	/*
 	 * Create the transient table that will receive the regenerated data. Lock

--- a/pg_ivm--1.10--1.11.sql
+++ b/pg_ivm--1.10--1.11.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pgivm.pg_ivm_immv ADD COLUMN querystring text;

--- a/pg_ivm--1.10--1.11.sql
+++ b/pg_ivm--1.10--1.11.sql
@@ -1,7 +1,7 @@
-ALTER TABLE pgivm.pg_ivm_immv ADD COLUMN querystring text;
+ALTER TABLE pgivm.pg_ivm_immv ADD COLUMN querystring text NOT NULL;
 
 CREATE FUNCTION pgivm.refresh_query_strings()
-RETURNS event_trigger LANGUAGE plpgsql AS
+RETURNS event_trigger LANGUAGE plpgsql SECURITY DEFINER AS
 $$
 DECLARE
 	old_search_path text;

--- a/pg_ivm--1.10--1.11.sql
+++ b/pg_ivm--1.10--1.11.sql
@@ -1,1 +1,23 @@
 ALTER TABLE pgivm.pg_ivm_immv ADD COLUMN querystring text;
+
+CREATE FUNCTION pgivm.refresh_query_strings()
+RETURNS event_trigger LANGUAGE plpgsql AS
+$$
+DECLARE
+	old_search_path text;
+BEGIN
+	-- Empty search path so that get_immv_def returns a fully-qualified query.
+	SELECT setting INTO old_search_path FROM pg_catalog.pg_settings
+		WHERE name = 'search_path';
+	SET search_path = '';
+
+	UPDATE pgivm.pg_ivm_immv SET querystring = pgivm.get_immv_def(immvrelid);
+
+	-- Reset search path to the original value.
+	EXECUTE format('SET search_path = %s', old_search_path);
+END
+$$;
+
+CREATE EVENT TRIGGER refresh_query_strings
+ON ddl_command_end
+EXECUTE FUNCTION pgivm.refresh_query_strings();

--- a/pg_ivm.c
+++ b/pg_ivm.c
@@ -458,3 +458,12 @@ PgIvmFuncName(char *name)
 {
     return list_make2(makeString("pgivm"), makeString(name));
 }
+
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM < 170000)
+void
+RestrictSearchPath(void)
+{
+	set_config_option("search_path", "pg_catalog, pg_temp", PGC_USERSET,
+					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
+}
+#endif

--- a/pg_ivm.control
+++ b/pg_ivm.control
@@ -1,6 +1,6 @@
 # incremental view maintenance extension_
 comment = 'incremental view maintenance on PostgreSQL'
-default_version = '1.10'
+default_version = '1.11'
 module_pathname = '$libdir/pg_ivm'
 relocatable = false 
 schema = pg_catalog

--- a/pg_ivm.h
+++ b/pg_ivm.h
@@ -35,6 +35,8 @@ extern Oid PgIvmImmvRelationId(void);
 extern Oid PgIvmImmvPrimaryKeyIndexId(void);
 extern bool isImmv(Oid immv_oid);
 extern List *PgIvmFuncName(char *name);
+extern void parse_immv_query(const char *relname, const char *sql,
+							 Query **query_ret, ParseState **pstate_ret);
 
 /* createas.c */
 

--- a/pg_ivm.h
+++ b/pg_ivm.h
@@ -65,8 +65,13 @@ extern bool isIvmName(const char *s);
 /* ruleutils.c */
 
 extern char *pg_ivm_get_viewdef(Relation immvrel, bool pretty);
+extern char *pg_ivm_get_viewdef_internal(Query *query, Relation immvrel, bool pretty);
 
 /* subselect.c */
 extern void inline_cte(PlannerInfo *root, CommonTableExpr *cte);
+
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM < 170000)
+extern void RestrictSearchPath(void);
+#endif
 
 #endif

--- a/pg_ivm.h
+++ b/pg_ivm.h
@@ -20,12 +20,13 @@
 #include "tcop/dest.h"
 #include "utils/queryenvironment.h"
 
-#define Natts_pg_ivm_immv 4
+#define Natts_pg_ivm_immv 5
 
 #define Anum_pg_ivm_immv_immvrelid 1
 #define Anum_pg_ivm_immv_viewdef 2
 #define Anum_pg_ivm_immv_ispopulated 3
 #define Anum_pg_ivm_immv_lastivmupdate 4
+#define Anum_pg_ivm_immv_querystring 5
 
 /* pg_ivm.c */
 

--- a/ruleutils.c
+++ b/ruleutils.c
@@ -43,6 +43,13 @@ char *
 pg_ivm_get_viewdef(Relation immvrel, bool pretty)
 {
 	Query *query = get_immv_query(immvrel);
+
+	return pg_ivm_get_viewdef_internal(query, immvrel, pretty);
+}
+
+char *
+pg_ivm_get_viewdef_internal(Query *query, Relation immvrel, bool pretty)
+{
 	TupleDesc resultDesc = RelationGetDescr(immvrel);
 
 #if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 150000)


### PR DESCRIPTION
Hi, I have been looking into how we can smoothly support pg_dump/restore/upgrade with this extension (#118). This PR is part one of my idea. Any feedback is welcome!

As I understand it, there are two fundamental problems.

- The triggers hard-code the IMMV OID, and this is not preserved by dump/restore.
- The `pg_ivm_immv` table stores a serialized Query tree, and this is not preserved by dump/restore or upgrade. Specifically dump/restore changes the referenced OIDs, and upgrade can change the Query tree struct itself.

This means after dump/restore or upgrade, the IMMVs are not usable. In fact, we can't even run `refresh_immv` to bring them back, because the original view query is lost.

This PR consists of a few changes:

- Add a `querystring text` column to `pg_ivm_immv`. This column stores the fully-qualified SQL query that defines this view.
- Add a DDL event trigger to update the `querystring` whenever an object is renamed. This is needed so that the querystring does not become stale if any referenced objects are renamed.
- Modify `RefreshIMMVByOid` so that it re-parses the `querystring` and stores the updated `viewdef` in `pg_ivm_immv`.
- Add a new SQL function `recreate_all_immvs` that refreshes all IMMVs. This re-populates the data and re-creates all the base table and change control triggers

With this change, a user can run pg_dump/restore/upgrade, then run `pgivm.recreate_all_immvs()` in order to restore their IMMVs to working order. They do not need to drop and re-create the IMMVs, and they do not need to input the original queries again.

I hope to find a way to automate the `pgivm.recreate_all_immvs()` step somehow. I played with creating executor/processutility hooks to automatically refresh the IMMVs during a restore/upgrade, but couldn't get it to work. I thought I would submit this portion of the PR first and get some feedback. Thanks!