### PR TITLE
Set the dependency type of Triggers to DEPENDENCY_INTERNAL

### DIFF
--- a/createas.c
+++ b/createas.c
@@ -759,7 +759,7 @@ CreateIvmTrigger(Oid relOid, Oid viewOid, int16 type, int16 timing, bool ex_lock
 	address = CreateTrigger(ivm_trigger, NULL, relOid, InvalidOid, InvalidOid,
 						 InvalidOid, InvalidOid, InvalidOid, NULL, true, false);
 
-	recordDependencyOn(&address, &refaddr, DEPENDENCY_AUTO);
+	recordDependencyOn(&address, &refaddr, DEPENDENCY_INTERNAL);
 
 	/* Make changes-so-far visible */
 	CommandCounterIncrement();

--- a/pg_ivm.c
+++ b/pg_ivm.c
@@ -315,7 +315,7 @@ CreateChangePreventTrigger(Oid matviewOid)
 		address = CreateTrigger(ivm_trigger, NULL, matviewOid, InvalidOid, InvalidOid,
 							 InvalidOid, InvalidOid, InvalidOid, NULL, true, false);
 
-		recordDependencyOn(&address, &refaddr, DEPENDENCY_AUTO);
+		recordDependencyOn(&address, &refaddr, DEPENDENCY_INTERNAL);
 	}
 
 	/* Make changes-so-far visible */


### PR DESCRIPTION
Issue #, if available:
#131 

Description of changes:
Set the Dependency type  to DEPENDENCY_INTERNAL from DEPENDENCY_AUTO.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.