### PR TITLE
Fix Windows linkage errors by adding PGDLLEXPORT to function declarations

### DIFF
--- a/pg_ivm.h
+++ b/pg_ivm.h
@@ -52,10 +52,10 @@ extern ObjectAddress ExecRefreshImmv(const RangeVar *relation, bool skipData,
 extern ObjectAddress RefreshImmvByOid(Oid matviewOid, bool is_create, bool skipData,
 									  const char *queryString, QueryCompletion *qc);
 extern bool ImmvIncrementalMaintenanceIsEnabled(void);
-extern Datum IVM_immediate_before(PG_FUNCTION_ARGS);
-extern Datum IVM_immediate_maintenance(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum IVM_immediate_before(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum IVM_immediate_maintenance(PG_FUNCTION_ARGS);
 extern Query* rewrite_query_for_exists_subquery(Query *query);
-extern Datum ivm_visible_in_prestate(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum ivm_visible_in_prestate(PG_FUNCTION_ARGS);
 extern void AtAbort_IVM(SubTransactionId subtxid);
 extern void AtPreCommit_IVM(void);
 extern char *getColumnNameStartWith(RangeTblEntry *rte, char *str, int *attnum);


### PR DESCRIPTION
## Summary

Fix build errors on Windows by adding PGDLLEXPORT to some function declarations in pg_ivm.h.

## Details

This PR adds the PGDLLEXPORT macro to the declarations of several functions (IVM_immediate_before, IVM_immediate_maintenance, ivm_visible_in_prestate) in pg_ivm.h.  
This resolves linkage errors that occurred when building pg_ivm on Windows with PostgreSQL 17.4 and Meson, due to mismatches between the function declarations and their definitions.

## References

- ISSUE #138
