### PR TITLE
Fix potential segmentation fault in create_immv

### DIFF
--- a/createas.c
+++ b/createas.c
@@ -1723,6 +1723,7 @@ StoreImmvQuery(Oid viewOid, Query *viewQuery)
 	values[Anum_pg_ivm_immv_immvrelid -1 ] = ObjectIdGetDatum(viewOid);
 	values[Anum_pg_ivm_immv_ispopulated -1 ] = BoolGetDatum(false);
 	values[Anum_pg_ivm_immv_viewdef -1 ] = CStringGetTextDatum(querytree);
+	isNulls[Anum_pg_ivm_immv_lastivmupdate -1 ] = true;
 
 	pgIvmImmv = table_open(PgIvmImmvRelationId(), RowExclusiveLock);
 


### PR DESCRIPTION
Ensure that newly added column information is passed to heap_form_tuple(). Previously, omission of this data led to a segmentation fault when building with MSVC, though the issue has not not observed on Linux.