### PR TITLE
Prefix role names in regression tests with "regress_"

### DIFF
--- a/expected/pg_ivm.out
+++ b/expected/pg_ivm.out
@@ -1533,17 +1533,17 @@ ERROR:  VALUES is not supported on incrementally maintainable materialized view
 SELECT pgivm.create_immv('mv_ivm_only_values2',  'SELECT * FROM (values(1)) AS tmp');
 ERROR:  VALUES is not supported on incrementally maintainable materialized view
 -- views containing base tables with Row Level Security
-DROP USER IF EXISTS ivm_admin;
-NOTICE:  role "ivm_admin" does not exist, skipping
-DROP USER IF EXISTS ivm_user;
-NOTICE:  role "ivm_user" does not exist, skipping
-CREATE USER ivm_admin;
-CREATE USER ivm_user;
+DROP USER IF EXISTS regress_ivm_admin;
+NOTICE:  role "regress_ivm_admin" does not exist, skipping
+DROP USER IF EXISTS regress_ivm_user;
+NOTICE:  role "regress_ivm_user" does not exist, skipping
+CREATE USER regress_ivm_admin;
+CREATE USER regress_ivm_user;
 --- create a table with RLS
-SET SESSION AUTHORIZATION ivm_admin;
+SET SESSION AUTHORIZATION regress_ivm_admin;
 CREATE TABLE rls_tbl(id int, data text, owner name);
 INSERT INTO rls_tbl VALUES
-  (1,'foo','ivm_user'),
+  (1,'foo','regress_ivm_user'),
   (2,'bar','postgres');
 CREATE TABLE num_tbl(id int, num text);
 INSERT INTO num_tbl VALUES
@@ -1558,8 +1558,8 @@ CREATE POLICY rls_tbl_policy ON rls_tbl FOR SELECT TO PUBLIC USING(owner = curre
 ALTER TABLE rls_tbl ENABLE ROW LEVEL SECURITY;
 GRANT ALL on rls_tbl TO PUBLIC;
 GRANT ALL on num_tbl TO PUBLIC;
---- create a view owned by ivm_user
-SET SESSION AUTHORIZATION ivm_user;
+--- create a view owned by regress_ivm_user
+SET SESSION AUTHORIZATION regress_ivm_user;
 SELECT pgivm.create_immv('ivm_rls', 'SELECT * FROM rls_tbl');
 NOTICE:  could not create an index on immv "ivm_rls" automatically
 DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
@@ -1570,42 +1570,42 @@ HINT:  Create an index on the immv for efficient incremental maintenance.
 (1 row)
 
 SELECT id, data, owner FROM ivm_rls ORDER BY 1,2,3;
- id | data |  owner   
-----+------+----------
-  1 | foo  | ivm_user
+ id | data |      owner       
+----+------+------------------
+  1 | foo  | regress_ivm_user
 (1 row)
 
 RESET SESSION AUTHORIZATION;
 --- inserts rows owned by different users
 INSERT INTO rls_tbl VALUES
-  (3,'baz','ivm_user'),
+  (3,'baz','regress_ivm_user'),
   (4,'qux','postgres');
 SELECT id, data, owner FROM ivm_rls ORDER BY 1,2,3;
- id | data |  owner   
-----+------+----------
-  1 | foo  | ivm_user
-  3 | baz  | ivm_user
+ id | data |      owner       
+----+------+------------------
+  1 | foo  | regress_ivm_user
+  3 | baz  | regress_ivm_user
 (2 rows)
 
 --- combination of diffent kinds of commands
 WITH
- i AS (INSERT INTO rls_tbl VALUES(5,'quux','postgres'), (6,'corge','ivm_user')),
+ i AS (INSERT INTO rls_tbl VALUES(5,'quux','postgres'), (6,'corge','regress_ivm_user')),
  u AS (UPDATE rls_tbl SET owner = 'postgres' WHERE id = 1),
- u2 AS (UPDATE rls_tbl SET owner = 'ivm_user' WHERE id = 2)
+ u2 AS (UPDATE rls_tbl SET owner = 'regress_ivm_user' WHERE id = 2)
 SELECT;
 --
 (1 row)
 
 SELECT id, data, owner FROM ivm_rls ORDER BY 1,2,3;
- id | data  |  owner   
-----+-------+----------
-  2 | bar   | ivm_user
-  3 | baz   | ivm_user
-  6 | corge | ivm_user
+ id | data  |      owner       
+----+-------+------------------
+  2 | bar   | regress_ivm_user
+  3 | baz   | regress_ivm_user
+  6 | corge | regress_ivm_user
 (3 rows)
 
 ---
-SET SESSION AUTHORIZATION ivm_user;
+SET SESSION AUTHORIZATION regress_ivm_user;
 SELECT pgivm.create_immv('ivm_rls2', 'SELECT * FROM rls_tbl JOIN num_tbl USING(id)');
 NOTICE:  could not create an index on immv "ivm_rls2" automatically
 DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
@@ -1624,11 +1624,11 @@ SELECT;
 (1 row)
 
 SELECT * FROM ivm_rls2 ORDER BY 1,2,3;
- id | data  |  owner   |   num   
-----+-------+----------+---------
-  2 | bar   | ivm_user | two
-  3 | baz_2 | ivm_user | three_2
-  6 | corge | ivm_user | six
+ id | data  |      owner       |   num   
+----+-------+------------------+---------
+  2 | bar   | regress_ivm_user | two
+  3 | baz_2 | regress_ivm_user | three_2
+  6 | corge | regress_ivm_user | six
 (3 rows)
 
 DROP TABLE rls_tbl CASCADE;
@@ -1636,8 +1636,8 @@ NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to table ivm_rls
 drop cascades to table ivm_rls2
 DROP TABLE num_tbl CASCADE;
-DROP USER ivm_user;
-DROP USER ivm_admin;
+DROP USER regress_ivm_user;
+DROP USER regress_ivm_admin;
 -- automatic index creation
 BEGIN;
 CREATE TABLE base_a (i int primary key, j int);

--- a/sql/pg_ivm.sql
+++ b/sql/pg_ivm.sql
@@ -596,16 +596,16 @@ SELECT pgivm.create_immv('mv_ivm_only_values2',  'SELECT * FROM (values(1)) AS t
 
 
 -- views containing base tables with Row Level Security
-DROP USER IF EXISTS ivm_admin;
-DROP USER IF EXISTS ivm_user;
-CREATE USER ivm_admin;
-CREATE USER ivm_user;
+DROP USER IF EXISTS regress_ivm_admin;
+DROP USER IF EXISTS regress_ivm_user;
+CREATE USER regress_ivm_admin;
+CREATE USER regress_ivm_user;
 
 --- create a table with RLS
-SET SESSION AUTHORIZATION ivm_admin;
+SET SESSION AUTHORIZATION regress_ivm_admin;
 CREATE TABLE rls_tbl(id int, data text, owner name);
 INSERT INTO rls_tbl VALUES
-  (1,'foo','ivm_user'),
+  (1,'foo','regress_ivm_user'),
   (2,'bar','postgres');
 CREATE TABLE num_tbl(id int, num text);
 INSERT INTO num_tbl VALUES
@@ -622,28 +622,28 @@ ALTER TABLE rls_tbl ENABLE ROW LEVEL SECURITY;
 GRANT ALL on rls_tbl TO PUBLIC;
 GRANT ALL on num_tbl TO PUBLIC;
 
---- create a view owned by ivm_user
-SET SESSION AUTHORIZATION ivm_user;
+--- create a view owned by regress_ivm_user
+SET SESSION AUTHORIZATION regress_ivm_user;
 SELECT pgivm.create_immv('ivm_rls', 'SELECT * FROM rls_tbl');
 SELECT id, data, owner FROM ivm_rls ORDER BY 1,2,3;
 RESET SESSION AUTHORIZATION;
 
 --- inserts rows owned by different users
 INSERT INTO rls_tbl VALUES
-  (3,'baz','ivm_user'),
+  (3,'baz','regress_ivm_user'),
   (4,'qux','postgres');
 SELECT id, data, owner FROM ivm_rls ORDER BY 1,2,3;
 
 --- combination of diffent kinds of commands
 WITH
- i AS (INSERT INTO rls_tbl VALUES(5,'quux','postgres'), (6,'corge','ivm_user')),
+ i AS (INSERT INTO rls_tbl VALUES(5,'quux','postgres'), (6,'corge','regress_ivm_user')),
  u AS (UPDATE rls_tbl SET owner = 'postgres' WHERE id = 1),
- u2 AS (UPDATE rls_tbl SET owner = 'ivm_user' WHERE id = 2)
+ u2 AS (UPDATE rls_tbl SET owner = 'regress_ivm_user' WHERE id = 2)
 SELECT;
 SELECT id, data, owner FROM ivm_rls ORDER BY 1,2,3;
 
 ---
-SET SESSION AUTHORIZATION ivm_user;
+SET SESSION AUTHORIZATION regress_ivm_user;
 SELECT pgivm.create_immv('ivm_rls2', 'SELECT * FROM rls_tbl JOIN num_tbl USING(id)');
 RESET SESSION AUTHORIZATION;
 
@@ -656,8 +656,8 @@ SELECT * FROM ivm_rls2 ORDER BY 1,2,3;
 DROP TABLE rls_tbl CASCADE;
 DROP TABLE num_tbl CASCADE;
 
-DROP USER ivm_user;
-DROP USER ivm_admin;
+DROP USER regress_ivm_user;
+DROP USER regress_ivm_admin;
 
 -- automatic index creation
 BEGIN;


### PR DESCRIPTION
Building PostgreSQL with -DENFORCE_REGRESSION_TEST_NAME_RESTRICTIONS causes the regression tests of pg_ivm to fail, because the role names used in the tests are not compliant with what upstream expects.

Enforcing restrictions in the regression tests is a good practice to have, as roles are shared objects and running the tests could manipulate existing clusters in unwanted ways.