### PR TITLE
Rework .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,30 @@
-# Global excludes across all subdirectories
-*.bc
+# Object files
 *.o
+
+# Coverage files
+*.gcno
+*.gcda
+
+# Libraries
+*.lib
+*.a
+
+# LLVM bitcode
+*.bc
+
+# Shared objects (inc. Windows DLLs)
+*.dll
 *.so
-regression.*
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.app
+
+# Dependencies
+.deps
 
 # Generated subdirectories
 /results/
+/output_iso/


### PR DESCRIPTION
This commit reworks .gitignore to be more portable depending on the options used in the PostgreSQL build this module links to, in various aspects:
- Ignore code generated for LLVM bitcode.
- Dependencies.
- Libraries.
- Coverage files.
- WIN32 and MacOS files.
- Ignore isolation test subdirectory.
- Do *not* ignore regression.diffs and regression.out.  This is more useful to detect if something is broken in the tree, in line with upstream core practices.

The contents of this file are updated to something closer to what upstream uses.