### PR TITLE
Fix incorrect maintenance when the same table is modified multiple ti…

### DIFF
--- a/expected/pg_ivm.out
+++ b/expected/pg_ivm.out
@@ -1645,6 +1645,51 @@ drop cascades to table ivm_rls2
 DROP TABLE num_tbl CASCADE;
 DROP USER regress_ivm_user;
 DROP USER regress_ivm_admin;
+-- trigger updating the same table
+BEGIN;
+CREATE TABLE tbl_update_same (i int);
+CREATE FUNCTION func_update_same() RETURNS TRIGGER AS
+ $$ BEGIN UPDATE tbl_update_same SET i = i + 1; RETURN NEW; END; $$
+ LANGUAGE plpgsql;
+CREATE TRIGGER trig_update_same AFTER INSERT ON tbl_update_same FOR EACH ROW
+ EXECUTE FUNCTION func_update_same();
+SELECT pgivm.create_immv('mv_update_same', 'SELECT * FROM tbl_update_same');
+NOTICE:  could not create an index on immv "mv_update_same" automatically
+DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
+HINT:  Create an index on the immv for efficient incremental maintenance.
+ create_immv 
+-------------
+           0
+(1 row)
+
+INSERT INTO tbl_update_same VALUES (1);
+SELECT * FROM mv_update_same;
+ i 
+---
+ 2
+(1 row)
+
+-- self-referential FKs
+CREATE TABLE tbl_self_ref (a int primary key,
+						   b int references tbl_self_ref(a) ON UPDATE CASCADE);
+INSERT INTO tbl_self_ref VALUES (1, null), (2, 1), (3, 2);
+SELECT pgivm.create_immv('mv_self_ref', 'SELECT * FROM tbl_self_ref');
+NOTICE:  created index "mv_self_ref_index" on immv "mv_self_ref"
+ create_immv 
+-------------
+           3
+(1 row)
+
+UPDATE tbl_self_ref set a = a + 10;
+SELECT * FROM mv_self_ref ORDER BY a;
+ a  | b  
+----+----
+ 11 |   
+ 12 | 11
+ 13 | 12
+(3 rows)
+
+ROLLBACK;
 -- automatic index creation
 BEGIN;
 CREATE TABLE base_a (i int primary key, j int);

--- a/matview.c
+++ b/matview.c
@@ -206,8 +206,8 @@ static char*make_subquery_targetlist_from_table(MV_TriggerTable *table);
 static char *make_delta_enr_name(const char *prefix, Oid relid, int count);
 static RangeTblEntry *get_prestate_rte(RangeTblEntry *rte, MV_TriggerTable *table,
 				 QueryEnvironment *queryEnv, Oid matviewid);
-static RangeTblEntry *union_ENRs(RangeTblEntry *rte, MV_TriggerTable *table, List *enr_rtes,
-		   const char *prefix, QueryEnvironment *queryEnv);
+static RangeTblEntry *makeDeltaTable(RangeTblEntry *rte, MV_TriggerTable *table,
+									 bool is_new, QueryEnvironment *queryEnv);
 static Query *rewrite_query_for_distinct_and_aggregates(Query *query, ParseState *pstate);
 
 static List *get_normalized_form(Query *query, Node *jtnode, Relids outer_join_rels,
@@ -780,7 +780,6 @@ tuplestore_copy(Tuplestorestate *tuplestore, Relation rel)
 
 	return res;
 }
-
 
 /* ----------------------------------------------------
  *		Incremental View Maintenance routines
@@ -1731,21 +1730,34 @@ get_prestate_rte(RangeTblEntry *rte, MV_TriggerTable *table,
 			subquery_tl, relname, matviewid);
 
 	/*
-	 * Append deleted rows contained in old transition tables.
+	 * Re-add rows deleted from the old transition tables, excluding those
+	 * also present in the new transition tables.
 	 *
-	 * Add a pseudo ctid to ENR using row_number(), which is required for
+	 * Also, add a pseudo ctid to ENR using row_number(), which is required for
 	 * calculating the number of dangling tuples to be inserted into
 	 * the outer join view.
 	 */
-	for (i = 0; i < list_length(table->old_tuplestores); i++)
+	if (list_length(table->old_tuplestores) > 0)
 	{
-		appendStringInfo(&str, " UNION ALL ");
-		appendStringInfo(&str," SELECT %s, "
-			" ((row_number() over())::text || '_' || '%d' || '_' || '%d') AS ctid"
-			" FROM %s",
-			subquery_tl,
-			table->table_id, i,
-			make_delta_enr_name("old", table->table_id, i));
+		appendStringInfo(&str," UNION ALL SELECT %s, "
+			" (pg_catalog.row_number() over())::text AS ctid"
+			" FROM (",
+			subquery_tl);
+
+		for (i = 0; i < list_length(table->old_tuplestores); i++)
+		{
+			if (i != 0)
+				appendStringInfo(&str, " UNION ALL ");
+			appendStringInfo(&str," TABLE %s",
+				make_delta_enr_name("old", table->table_id, i));
+		}
+		for (i = 0; i < list_length(table->new_tuplestores); i++)
+		{
+			appendStringInfo(&str, " EXCEPT ALL ");
+			appendStringInfo(&str," TABLE %s",
+				make_delta_enr_name("new", table->table_id, i));
+		}
+		appendStringInfo(&str,")");
 	}
 
 	/* Get a subquery representing pre-state of the table */
@@ -1845,18 +1857,22 @@ make_delta_enr_name(const char *prefix, Oid relid, int count)
 /*
  * union_ENRs
  *
- * Replace RTE of the modified table with a single table delta that combine its
- * all transition tables.
+ * Make a RTE representing a delta of the specified table.
  */
 static RangeTblEntry*
-union_ENRs(RangeTblEntry *rte, MV_TriggerTable *table, List *enr_rtes,
-		   const char *prefix, QueryEnvironment *queryEnv)
+makeDeltaTable(RangeTblEntry *rte, MV_TriggerTable *table,
+		   bool is_new, QueryEnvironment *queryEnv)
 {
 	StringInfoData str;
 	ParseState	*pstate;
 	RawStmt *raw;
 	Query *sub;
 	int	i;
+
+	const char *prefix_union = is_new ? "new" : "old";
+	const char *prefix_except = is_new ? "old" : "new";
+	int num_union = is_new ? list_length(table->new_rtes) : list_length(table->old_rtes);
+	int num_except = is_new ? list_length(table->old_rtes) : list_length(table->new_rtes);
 
 	/* the previous RTE must be a subquery which represents "pre-state" table */
 	Assert(rte->rtekind == RTE_SUBQUERY);
@@ -1866,25 +1882,36 @@ union_ENRs(RangeTblEntry *rte, MV_TriggerTable *table, List *enr_rtes,
 	pstate->p_queryEnv = queryEnv;
 	pstate->p_expr_kind = EXPR_KIND_SELECT_TARGET;
 
+	/*
+	 * Add a pseudo ctid to ENR using row_number(), which is required for
+	 * calculating the number of dangling tuples to be inserted into
+	 * the outer join view.
+	 */
 	initStringInfo(&str);
-	for (i = 0; i < list_length(enr_rtes); i++)
+	appendStringInfo(&str,
+		" SELECT %s,  "
+		" (pg_catalog.row_number() over())::text AS ctid"
+		" FROM (",
+		make_subquery_targetlist_from_table(table));
+
+	for (i = 0; i < num_union; i++)
 	{
 		if (i > 0)
 			appendStringInfo(&str, " UNION ALL ");
 
-		/*
-		 * Add a pseudo ctid to ENR using row_number(), which is required for
-		 * calculating the number of dangling tuples to be inserted into
-		 * the outer join view.
-		 */
 		appendStringInfo(&str,
-			" SELECT %s,  "
-			" ((row_number() over())::text || '_' || '%d' || '_' || '%d') AS ctid"
-			" FROM %s",
-			make_subquery_targetlist_from_table(table),
-			table->table_id, i,
-			make_delta_enr_name(prefix, table->table_id, i));
+			" TABLE  %s",
+			make_delta_enr_name(prefix_union, table->table_id, i));
 	}
+	for (i = 0; i < num_except; i++)
+	{
+		appendStringInfo(&str, " EXCEPT ALL ");
+
+		appendStringInfo(&str,
+			" TABLE  %s",
+			make_delta_enr_name(prefix_except, table->table_id, i));
+	}
+	appendStringInfo(&str,")");
 
 #if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 140000)
 	raw = (RawStmt*)linitial(raw_parser(str.data, RAW_PARSE_DEFAULT));
@@ -2764,7 +2791,7 @@ calc_delta(MV_TriggerTable *table, List *rte_path, Query *query,
 	if (dest_old && list_length(table->old_rtes) > 0)
 	{
 		/* Replace the modified table with the old delta table and calculate the old view delta. */
-		lfirst(lc) = union_ENRs(rte, table, table->old_rtes, "old", queryEnv);
+		lfirst(lc) = makeDeltaTable(rte, table, false, queryEnv);
 		refresh_immv_datafill(dest_old, query, queryEnv, tupdesc_old, "");
 	}
 
@@ -2772,7 +2799,7 @@ calc_delta(MV_TriggerTable *table, List *rte_path, Query *query,
 	if (dest_new && list_length(table->new_rtes) > 0)
 	{
 		/* Replace the modified table with the new delta table and calculate the new view delta*/
-		lfirst(lc) = union_ENRs(rte, table, table->new_rtes, "new", queryEnv);
+		lfirst(lc) = makeDeltaTable(rte, table, true, queryEnv);
 		refresh_immv_datafill(dest_new, query, queryEnv, tupdesc_new, "");
 	}
 

--- a/pg_ivm.c
+++ b/pg_ivm.c
@@ -21,6 +21,7 @@
 #include "catalog/pg_namespace_d.h"
 #include "catalog/pg_trigger_d.h"
 #include "commands/trigger.h"
+#include "executor/executor.h"
 #include "parser/analyze.h"
 #include "parser/parser.h"
 #include "parser/scansup.h"

--- a/sql/pg_ivm.sql
+++ b/sql/pg_ivm.sql
@@ -661,6 +661,27 @@ DROP TABLE num_tbl CASCADE;
 DROP USER regress_ivm_user;
 DROP USER regress_ivm_admin;
 
+-- trigger updating the same table
+BEGIN;
+CREATE TABLE tbl_update_same (i int);
+CREATE FUNCTION func_update_same() RETURNS TRIGGER AS
+ $$ BEGIN UPDATE tbl_update_same SET i = i + 1; RETURN NEW; END; $$
+ LANGUAGE plpgsql;
+CREATE TRIGGER trig_update_same AFTER INSERT ON tbl_update_same FOR EACH ROW
+ EXECUTE FUNCTION func_update_same();
+SELECT pgivm.create_immv('mv_update_same', 'SELECT * FROM tbl_update_same');
+INSERT INTO tbl_update_same VALUES (1);
+SELECT * FROM mv_update_same;
+
+-- self-referential FKs
+CREATE TABLE tbl_self_ref (a int primary key,
+						   b int references tbl_self_ref(a) ON UPDATE CASCADE);
+INSERT INTO tbl_self_ref VALUES (1, null), (2, 1), (3, 2);
+SELECT pgivm.create_immv('mv_self_ref', 'SELECT * FROM tbl_self_ref');
+UPDATE tbl_self_ref set a = a + 10;
+SELECT * FROM mv_self_ref ORDER BY a;
+ROLLBACK;
+
 -- automatic index creation
 BEGIN;
 CREATE TABLE base_a (i int primary key, j int);


### PR DESCRIPTION
…mes by triggers

Previously, if a table was modified multiple times by a user-defined trigger or an RI trigger, incremental maintenance could produce inconsistent results or lead to duplicate key violations.

For example, suppose a row is inserted by the main query and then updated by a trigger. This generates two sets of transition tables: one with the row in NEW and another with the same row in OLD.

When pg_ivm processes these transition tables in a batch, it handles the OLD table before the NEW one. As a result, it first tries to remove a non-existent row from the view, and then attempts to insert rows from NEW, including a row that should have been canceled out by the corresponding OLD entry, leading to incorrect results.

In addition, if a table has self-referencing FKs, rows can appear in both OLD and NEW transition tables even without user-defined triggers, with only a single set of transition tables generated. This case also leads to incorrect results.

To fix this, rows common to both NEW and OLD transition tables are removed using EXCEPT ALL in the subqueries representing table deltas and the pre-update state.

(Issue #127)