### PR TITLE
Fix "could not obtain lock" error

### DIFF
--- a/expected/insert_insert2.out
+++ b/expected/insert_insert2.out
@@ -4,9 +4,10 @@ starting permutation: s1 update1 s2 update2 c1 check2 c2 mv
 step s1: SELECT;
 step update1: UPDATE a SET j = 11 WHERE i = 1;
 step s2: SELECT;
-step update2: UPDATE b SET j = 111 WHERE i = 1;
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step update2: UPDATE b SET j = 111 WHERE i = 1; <waiting ...>
 step c1: COMMIT;
+step update2: <... completed>
+ERROR:  the materialized view is incrementally updated in concurrent transaction
 step check2: SELECT check_mv();
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step c2: COMMIT;
@@ -48,9 +49,10 @@ starting permutation: s1 s2 update1 update2 c1 check2 c2 mv
 step s1: SELECT;
 step s2: SELECT;
 step update1: UPDATE a SET j = 11 WHERE i = 1;
-step update2: UPDATE b SET j = 111 WHERE i = 1;
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step update2: UPDATE b SET j = 111 WHERE i = 1; <waiting ...>
 step c1: COMMIT;
+step update2: <... completed>
+ERROR:  the materialized view is incrementally updated in concurrent transaction
 step check2: SELECT check_mv();
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step c2: COMMIT;
@@ -70,9 +72,10 @@ starting permutation: s1 s2 update2 update1 c2 check1 c1 mv
 step s1: SELECT;
 step s2: SELECT;
 step update2: UPDATE b SET j = 111 WHERE i = 1;
-step update1: UPDATE a SET j = 11 WHERE i = 1;
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step update1: UPDATE a SET j = 11 WHERE i = 1; <waiting ...>
 step c2: COMMIT;
+step update1: <... completed>
+ERROR:  the materialized view is incrementally updated in concurrent transaction
 step check1: SELECT check_mv();
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step c1: COMMIT;
@@ -114,9 +117,10 @@ starting permutation: s2 update2 s1 update1 c2 check1 c1 mv
 step s2: SELECT;
 step update2: UPDATE b SET j = 111 WHERE i = 1;
 step s1: SELECT;
-step update1: UPDATE a SET j = 11 WHERE i = 1;
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step update1: UPDATE a SET j = 11 WHERE i = 1; <waiting ...>
 step c2: COMMIT;
+step update1: <... completed>
+ERROR:  the materialized view is incrementally updated in concurrent transaction
 step check1: SELECT check_mv();
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step c1: COMMIT;
@@ -180,9 +184,10 @@ starting permutation: s1 insert1 s2 insert2 c1 check2 c2 mv
 step s1: SELECT;
 step insert1: INSERT INTO a VALUES (2,20); INSERT INTO b VALUES (2,200);
 step s2: SELECT;
-step insert2: INSERT INTO a VALUES (1,11), (2,21); INSERT INTO b VALUES (2,201);
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step insert2: INSERT INTO a VALUES (1,11), (2,21); INSERT INTO b VALUES (2,201); <waiting ...>
 step c1: COMMIT;
+step insert2: <... completed>
+ERROR:  the materialized view is incrementally updated in concurrent transaction
 step check2: SELECT check_mv();
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step c2: COMMIT;
@@ -226,9 +231,10 @@ starting permutation: s1 s2 insert1 insert2 c1 check2 c2 mv
 step s1: SELECT;
 step s2: SELECT;
 step insert1: INSERT INTO a VALUES (2,20); INSERT INTO b VALUES (2,200);
-step insert2: INSERT INTO a VALUES (1,11), (2,21); INSERT INTO b VALUES (2,201);
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step insert2: INSERT INTO a VALUES (1,11), (2,21); INSERT INTO b VALUES (2,201); <waiting ...>
 step c1: COMMIT;
+step insert2: <... completed>
+ERROR:  the materialized view is incrementally updated in concurrent transaction
 step check2: SELECT check_mv();
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step c2: COMMIT;
@@ -249,9 +255,10 @@ starting permutation: s1 s2 insert2 insert1 c2 check1 c1 mv
 step s1: SELECT;
 step s2: SELECT;
 step insert2: INSERT INTO a VALUES (1,11), (2,21); INSERT INTO b VALUES (2,201);
-step insert1: INSERT INTO a VALUES (2,20); INSERT INTO b VALUES (2,200);
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step insert1: INSERT INTO a VALUES (2,20); INSERT INTO b VALUES (2,200); <waiting ...>
 step c2: COMMIT;
+step insert1: <... completed>
+ERROR:  the materialized view is incrementally updated in concurrent transaction
 step check1: SELECT check_mv();
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step c1: COMMIT;
@@ -298,9 +305,10 @@ starting permutation: s2 insert2 s1 insert1 c2 check1 c1 mv
 step s2: SELECT;
 step insert2: INSERT INTO a VALUES (1,11), (2,21); INSERT INTO b VALUES (2,201);
 step s1: SELECT;
-step insert1: INSERT INTO a VALUES (2,20); INSERT INTO b VALUES (2,200);
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step insert1: INSERT INTO a VALUES (2,20); INSERT INTO b VALUES (2,200); <waiting ...>
 step c2: COMMIT;
+step insert1: <... completed>
+ERROR:  the materialized view is incrementally updated in concurrent transaction
 step check1: SELECT check_mv();
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step c1: COMMIT;

--- a/expected/insert_insert3.out
+++ b/expected/insert_insert3.out
@@ -4,9 +4,10 @@ starting permutation: s1 update1 s2 update2 c1 check2 c2 mv
 step s1: SELECT;
 step update1: UPDATE a SET j = 11 WHERE i = 1;
 step s2: SELECT;
-step update2: UPDATE b SET j = 111 WHERE i = 1;
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step update2: UPDATE b SET j = 111 WHERE i = 1; <waiting ...>
 step c1: COMMIT;
+step update2: <... completed>
+ERROR:  the materialized view is incrementally updated in concurrent transaction
 step check2: SELECT check_mv();
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step c2: COMMIT;
@@ -48,9 +49,10 @@ starting permutation: s1 s2 update1 update2 c1 check2 c2 mv
 step s1: SELECT;
 step s2: SELECT;
 step update1: UPDATE a SET j = 11 WHERE i = 1;
-step update2: UPDATE b SET j = 111 WHERE i = 1;
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step update2: UPDATE b SET j = 111 WHERE i = 1; <waiting ...>
 step c1: COMMIT;
+step update2: <... completed>
+ERROR:  the materialized view is incrementally updated in concurrent transaction
 step check2: SELECT check_mv();
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step c2: COMMIT;
@@ -70,9 +72,10 @@ starting permutation: s1 s2 update2 update1 c2 check1 c1 mv
 step s1: SELECT;
 step s2: SELECT;
 step update2: UPDATE b SET j = 111 WHERE i = 1;
-step update1: UPDATE a SET j = 11 WHERE i = 1;
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step update1: UPDATE a SET j = 11 WHERE i = 1; <waiting ...>
 step c2: COMMIT;
+step update1: <... completed>
+ERROR:  the materialized view is incrementally updated in concurrent transaction
 step check1: SELECT check_mv();
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step c1: COMMIT;
@@ -114,9 +117,10 @@ starting permutation: s2 update2 s1 update1 c2 check1 c1 mv
 step s2: SELECT;
 step update2: UPDATE b SET j = 111 WHERE i = 1;
 step s1: SELECT;
-step update1: UPDATE a SET j = 11 WHERE i = 1;
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step update1: UPDATE a SET j = 11 WHERE i = 1; <waiting ...>
 step c2: COMMIT;
+step update1: <... completed>
+ERROR:  the materialized view is incrementally updated in concurrent transaction
 step check1: SELECT check_mv();
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step c1: COMMIT;
@@ -180,9 +184,10 @@ starting permutation: s1 insert1 s2 insert2 c1 check2 c2 mv
 step s1: SELECT;
 step insert1: INSERT INTO a VALUES (2,20); INSERT INTO b VALUES (2,200);
 step s2: SELECT;
-step insert2: INSERT INTO a VALUES (1,11), (2,21); INSERT INTO b VALUES (2,201);
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step insert2: INSERT INTO a VALUES (1,11), (2,21); INSERT INTO b VALUES (2,201); <waiting ...>
 step c1: COMMIT;
+step insert2: <... completed>
+ERROR:  the materialized view is incrementally updated in concurrent transaction
 step check2: SELECT check_mv();
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step c2: COMMIT;
@@ -226,9 +231,10 @@ starting permutation: s1 s2 insert1 insert2 c1 check2 c2 mv
 step s1: SELECT;
 step s2: SELECT;
 step insert1: INSERT INTO a VALUES (2,20); INSERT INTO b VALUES (2,200);
-step insert2: INSERT INTO a VALUES (1,11), (2,21); INSERT INTO b VALUES (2,201);
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step insert2: INSERT INTO a VALUES (1,11), (2,21); INSERT INTO b VALUES (2,201); <waiting ...>
 step c1: COMMIT;
+step insert2: <... completed>
+ERROR:  the materialized view is incrementally updated in concurrent transaction
 step check2: SELECT check_mv();
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step c2: COMMIT;
@@ -249,9 +255,10 @@ starting permutation: s1 s2 insert2 insert1 c2 check1 c1 mv
 step s1: SELECT;
 step s2: SELECT;
 step insert2: INSERT INTO a VALUES (1,11), (2,21); INSERT INTO b VALUES (2,201);
-step insert1: INSERT INTO a VALUES (2,20); INSERT INTO b VALUES (2,200);
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step insert1: INSERT INTO a VALUES (2,20); INSERT INTO b VALUES (2,200); <waiting ...>
 step c2: COMMIT;
+step insert1: <... completed>
+ERROR:  the materialized view is incrementally updated in concurrent transaction
 step check1: SELECT check_mv();
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step c1: COMMIT;
@@ -298,9 +305,10 @@ starting permutation: s2 insert2 s1 insert1 c2 check1 c1 mv
 step s2: SELECT;
 step insert2: INSERT INTO a VALUES (1,11), (2,21); INSERT INTO b VALUES (2,201);
 step s1: SELECT;
-step insert1: INSERT INTO a VALUES (2,20); INSERT INTO b VALUES (2,200);
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step insert1: INSERT INTO a VALUES (2,20); INSERT INTO b VALUES (2,200); <waiting ...>
 step c2: COMMIT;
+step insert1: <... completed>
+ERROR:  the materialized view is incrementally updated in concurrent transaction
 step check1: SELECT check_mv();
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step c1: COMMIT;

--- a/expected/refresh_insert2.out
+++ b/expected/refresh_insert2.out
@@ -9,17 +9,22 @@ refresh_immv
 (1 row)
 
 step s2: SELECT;
-step insert: INSERT INTO a VALUES (2);
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step insert: INSERT INTO a VALUES (2); <waiting ...>
 step c1: COMMIT;
+step insert: <... completed>
 step check2: SELECT check_mv();
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+check_mv
+--------
+ok      
+(1 row)
+
 step c2: COMMIT;
 step mv: SELECT * FROM mv ORDER BY 1,2; SELECT check_mv();
 x|y
 -+-
 1|1
-(1 row)
+2|2
+(2 rows)
 
 check_mv
 --------
@@ -67,17 +72,22 @@ refresh_immv
            1
 (1 row)
 
-step insert: INSERT INTO a VALUES (2);
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step insert: INSERT INTO a VALUES (2); <waiting ...>
 step c1: COMMIT;
+step insert: <... completed>
 step check2: SELECT check_mv();
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+check_mv
+--------
+ok      
+(1 row)
+
 step c2: COMMIT;
 step mv: SELECT * FROM mv ORDER BY 1,2; SELECT check_mv();
 x|y
 -+-
 1|1
-(1 row)
+2|2
+(2 rows)
 
 check_mv
 --------

--- a/expected/refresh_insert3.out
+++ b/expected/refresh_insert3.out
@@ -9,17 +9,22 @@ refresh_immv
 (1 row)
 
 step s2: SELECT;
-step insert: INSERT INTO a VALUES (2);
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step insert: INSERT INTO a VALUES (2); <waiting ...>
 step c1: COMMIT;
+step insert: <... completed>
 step check2: SELECT check_mv();
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+check_mv
+--------
+ok      
+(1 row)
+
 step c2: COMMIT;
 step mv: SELECT * FROM mv ORDER BY 1,2; SELECT check_mv();
 x|y
 -+-
 1|1
-(1 row)
+2|2
+(2 rows)
 
 check_mv
 --------
@@ -67,17 +72,22 @@ refresh_immv
            1
 (1 row)
 
-step insert: INSERT INTO a VALUES (2);
-ERROR:  could not obtain lock on materialized view "mv" during incremental maintenance
+step insert: INSERT INTO a VALUES (2); <waiting ...>
 step c1: COMMIT;
+step insert: <... completed>
 step check2: SELECT check_mv();
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+check_mv
+--------
+ok      
+(1 row)
+
 step c2: COMMIT;
 step mv: SELECT * FROM mv ORDER BY 1,2; SELECT check_mv();
 x|y
 -+-
 1|1
-(1 row)
+2|2
+(2 rows)
 
 check_mv
 --------

--- a/matview.c
+++ b/matview.c
@@ -812,30 +812,8 @@ IVM_immediate_before(PG_FUNCTION_ARGS)
 	{
 		FullTransactionId xid;
 
-		/*
-		 * Wait for concurrent transactions which update this materialized view at
-		 * READ COMMITED. This is needed to see changes committed in other
-		 * transactions. No wait and raise an error at REPEATABLE READ or
-		 * SERIALIZABLE to prevent update anomalies of matviews.
-		 * XXX: dead-lock is possible here.
-		 */
-		if (!IsolationUsesXactSnapshot())
-			LockRelationOid(matviewOid, ExclusiveLock);
-		else if (!ConditionalLockRelationOid(matviewOid, ExclusiveLock))
-		{
-			/* try to throw error by name; relation could be deleted... */
-			char	   *relname = get_rel_name(matviewOid);
-
-			if (!relname)
-				ereport(ERROR,
-						(errcode(ERRCODE_LOCK_NOT_AVAILABLE),
-						errmsg("could not obtain lock on materialized view during incremental maintenance")));
-
-			ereport(ERROR,
-					(errcode(ERRCODE_LOCK_NOT_AVAILABLE),
-					errmsg("could not obtain lock on materialized view \"%s\" during incremental maintenance",
-							relname)));
-		}
+    /* XXX: dead-lock is possible here. */
+    LockRelationOid(matviewOid, ExclusiveLock);
 
 		/*
 		 * Even if we can acquire an lock, a concurrent transaction could have


### PR DESCRIPTION
In REPEATABLE READ / SERIALIZABLE, IVM_immediate_before() took the matview lock with a no-wait ConditionalLockRelationOid() and errored immediately when it was busy. But that lock is also held briefly by create_immv()/refresh_immv(), and commit releases locks one at a time, so a waiter can reach the matview lock before the committer has released it and fail with a spurious "could not obtain lock" error with no concurrent maintenance actually in progress. This made create_insert2/create_insert3 flaky under load.

Just wait for the lock, as READ COMMITTED already did. Real anomalies are still caught by the existing last-update XID check right after, which is independent of how the lock was acquired.

Isolation test expected outputs are updated accordingly. 

Fixes #153