### PR TITLE
PostgreSQL 19 compatibility fixes

### DIFF
--- a/createas.c
+++ b/createas.c
@@ -1729,13 +1729,17 @@ CreateIndexOnIMMV(Query *query, Relation matviewRel)
 			return;
 	}
 
-	address = DefineIndex(RelationGetRelid(matviewRel),
+	address = DefineIndex(
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 190000)
+						  NULL,			/* pstate -- new in PG19 */
+#endif
+						  RelationGetRelid(matviewRel),
 						  index,
 						  InvalidOid,
 						  InvalidOid,
 						  InvalidOid,
 #if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 160000)
-						  -1,
+						  -1,			/* total_parts -- added in PG16 */
 #endif
 						  false, true, false, false, true);
 

--- a/createas.c
+++ b/createas.c
@@ -1729,7 +1729,12 @@ CreateIndexOnIMMV(Query *query, Relation matviewRel)
 			return;
 	}
 
-	address = DefineIndex(RelationGetRelid(matviewRel),
+	address = DefineIndex(
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 190000)
+						  NULL,	/* pstate; no parse state for this
+								 * internally generated index */
+#endif
+						  RelationGetRelid(matviewRel),
 						  index,
 						  InvalidOid,
 						  InvalidOid,

--- a/createas.c
+++ b/createas.c
@@ -1729,17 +1729,13 @@ CreateIndexOnIMMV(Query *query, Relation matviewRel)
 			return;
 	}
 
-	address = DefineIndex(
-#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 190000)
-						  NULL,			/* pstate -- new in PG19 */
-#endif
-						  RelationGetRelid(matviewRel),
+	address = DefineIndex(RelationGetRelid(matviewRel),
 						  index,
 						  InvalidOid,
 						  InvalidOid,
 						  InvalidOid,
 #if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 160000)
-						  -1,			/* total_parts -- added in PG16 */
+						  -1,
 #endif
 						  false, true, false, false, true);
 

--- a/matview.c
+++ b/matview.c
@@ -20,7 +20,12 @@
 #include "catalog/heap.h"
 #include "catalog/pg_collation_d.h"
 #include "catalog/pg_trigger.h"
+/* commands/cluster.h was renamed to commands/repack.h in PG19 */
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 190000)
+#include "commands/repack.h"
+#else
 #include "commands/cluster.h"
+#endif
 #include "commands/defrem.h"
 #include "commands/matview.h"
 #include "commands/tablecmds.h"
@@ -645,7 +650,11 @@ refresh_immv_datafill(DestReceiver *dest, Query *query,
 	CHECK_FOR_INTERRUPTS();
 
 	/* Plan the query which will generate data for the refresh. */
-	plan = pg_plan_query(query, queryString, CURSOR_OPT_PARALLEL_OK, NULL);
+	plan = pg_plan_query(query, queryString, CURSOR_OPT_PARALLEL_OK, NULL
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 190000)
+						 , NULL		/* ExplainState -- new in PG19 */
+#endif
+						 );
 
 	/*
 	 * Use a snapshot with an updated command ID to ensure this query sees
@@ -696,6 +705,9 @@ static void
 refresh_by_heap_swap(Oid matviewOid, Oid OIDNewHeap, char relpersistence)
 {
 	finish_heap_swap(matviewOid, OIDNewHeap, false, false, true, true,
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 190000)
+					 false,		/* reindex -- new in PG19 */
+#endif
 					 RecentXmin, ReadNextMultiXactId(), relpersistence);
 }
 

--- a/matview.c
+++ b/matview.c
@@ -20,7 +20,14 @@
 #include "catalog/heap.h"
 #include "catalog/pg_collation_d.h"
 #include "catalog/pg_trigger.h"
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 190000)
+#include "commands/repack.h"	/* commands/cluster.h was renamed to
+								 * commands/repack.h when CLUSTER/VACUUM
+								 * FULL were merged into the new REPACK
+								 * command */
+#else
 #include "commands/cluster.h"
+#endif
 #include "commands/defrem.h"
 #include "commands/matview.h"
 #include "commands/tablecmds.h"
@@ -645,7 +652,11 @@ refresh_immv_datafill(DestReceiver *dest, Query *query,
 	CHECK_FOR_INTERRUPTS();
 
 	/* Plan the query which will generate data for the refresh. */
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 190000)
+	plan = pg_plan_query(query, queryString, CURSOR_OPT_PARALLEL_OK, NULL, NULL);
+#else
 	plan = pg_plan_query(query, queryString, CURSOR_OPT_PARALLEL_OK, NULL);
+#endif
 
 	/*
 	 * Use a snapshot with an updated command ID to ensure this query sees
@@ -695,8 +706,14 @@ refresh_immv_datafill(DestReceiver *dest, Query *query,
 static void
 refresh_by_heap_swap(Oid matviewOid, Oid OIDNewHeap, char relpersistence)
 {
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 190000)
+	finish_heap_swap(matviewOid, OIDNewHeap, false, false, true, true,
+					 true,		/* reindex */
+					 RecentXmin, ReadNextMultiXactId(), relpersistence);
+#else
 	finish_heap_swap(matviewOid, OIDNewHeap, false, false, true, true,
 					 RecentXmin, ReadNextMultiXactId(), relpersistence);
+#endif
 }
 
 /*

--- a/matview.c
+++ b/matview.c
@@ -20,12 +20,7 @@
 #include "catalog/heap.h"
 #include "catalog/pg_collation_d.h"
 #include "catalog/pg_trigger.h"
-/* commands/cluster.h was renamed to commands/repack.h in PG19 */
-#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 190000)
-#include "commands/repack.h"
-#else
 #include "commands/cluster.h"
-#endif
 #include "commands/defrem.h"
 #include "commands/matview.h"
 #include "commands/tablecmds.h"
@@ -650,11 +645,7 @@ refresh_immv_datafill(DestReceiver *dest, Query *query,
 	CHECK_FOR_INTERRUPTS();
 
 	/* Plan the query which will generate data for the refresh. */
-	plan = pg_plan_query(query, queryString, CURSOR_OPT_PARALLEL_OK, NULL
-#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 190000)
-						 , NULL		/* ExplainState -- new in PG19 */
-#endif
-						 );
+	plan = pg_plan_query(query, queryString, CURSOR_OPT_PARALLEL_OK, NULL);
 
 	/*
 	 * Use a snapshot with an updated command ID to ensure this query sees
@@ -705,9 +696,6 @@ static void
 refresh_by_heap_swap(Oid matviewOid, Oid OIDNewHeap, char relpersistence)
 {
 	finish_heap_swap(matviewOid, OIDNewHeap, false, false, true, true,
-#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 190000)
-					 false,		/* reindex -- new in PG19 */
-#endif
 					 RecentXmin, ReadNextMultiXactId(), relpersistence);
 }
 


### PR DESCRIPTION
 createas.c:
   - DefineIndex() gained a new leading ParseState *pstate argument in PG19. The old first argument (Oid tableId) shifted to second position; all subsequent arguments follow unchanged.  Pass NULL (no parse state needed here).  Guarded by PG_VERSION_NUM >= 190000; the PG16 total_parts (-1) guard is preserved as-is.

 matview.c:
   - commands/cluster.h was renamed to commands/repack.h in PG19 as part of the CLUSTER→REPACK command consolidation (commit c0b53ec06). Added a version-guarded #include to select the correct header.

   - pg_plan_query() gained a trailing ExplainState *es argument in PG19 (added to support pg_plan_advice integration).  Pass NULL. Guarded by PG_VERSION_NUM >= 190000.

   - finish_heap_swap() gained a new bool reindex parameter at position 7 in PG19 (inserted between is_internal and frozenXid).  Pass false (no reindex needed for IMMV heap swap). Guarded by PG_VERSION_NUM >= 190000.

Coded by Claude, tested by me.

Per https://github.com/pgdg-packaging/pgdg-rpms/issues/213