### PR TITLE
Fix subquery alias

### DIFF
--- a/expected/pg_ivm_0.out
+++ b/expected/pg_ivm_0.out
@@ -1643,6 +1643,51 @@ drop cascades to table ivm_rls2
 DROP TABLE num_tbl CASCADE;
 DROP USER regress_ivm_user;
 DROP USER regress_ivm_admin;
+-- trigger updating the same table
+BEGIN;
+CREATE TABLE tbl_update_same (i int);
+CREATE FUNCTION func_update_same() RETURNS TRIGGER AS
+ $$ BEGIN UPDATE tbl_update_same SET i = i + 1; RETURN NEW; END; $$
+ LANGUAGE plpgsql;
+CREATE TRIGGER trig_update_same AFTER INSERT ON tbl_update_same FOR EACH ROW
+ EXECUTE FUNCTION func_update_same();
+SELECT pgivm.create_immv('mv_update_same', 'SELECT * FROM tbl_update_same');
+NOTICE:  could not create an index on immv "mv_update_same" automatically
+DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
+HINT:  Create an index on the immv for efficient incremental maintenance.
+ create_immv 
+-------------
+           0
+(1 row)
+
+INSERT INTO tbl_update_same VALUES (1);
+SELECT * FROM mv_update_same;
+ i 
+---
+ 2
+(1 row)
+
+-- self-referential FKs
+CREATE TABLE tbl_self_ref (a int primary key,
+						   b int references tbl_self_ref(a) ON UPDATE CASCADE);
+INSERT INTO tbl_self_ref VALUES (1, null), (2, 1), (3, 2);
+SELECT pgivm.create_immv('mv_self_ref', 'SELECT * FROM tbl_self_ref');
+NOTICE:  created index "mv_self_ref_index" on immv "mv_self_ref"
+ create_immv 
+-------------
+           3
+(1 row)
+
+UPDATE tbl_self_ref set a = a + 10;
+SELECT * FROM mv_self_ref ORDER BY a;
+ a  | b  
+----+----
+ 11 |   
+ 12 | 11
+ 13 | 12
+(3 rows)
+
+ROLLBACK;
 -- automatic index creation
 BEGIN;
 CREATE TABLE base_a (i int primary key, j int);

--- a/matview.c
+++ b/matview.c
@@ -1711,7 +1711,6 @@ get_prestate_rte(RangeTblEntry *rte, MV_TriggerTable *table,
 
 	pstate = make_parsestate(NULL);
 	pstate->p_queryEnv = queryEnv;
-	pstate->p_expr_kind = EXPR_KIND_SELECT_TARGET;
 
 	relname = quote_qualified_identifier(
 					get_namespace_name(RelationGetNamespace(table->rel)),
@@ -1758,6 +1757,9 @@ get_prestate_rte(RangeTblEntry *rte, MV_TriggerTable *table,
 				make_delta_enr_name("new", table->table_id, i));
 		}
 		appendStringInfo(&str,")");
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM < 160000)
+		appendStringInfo(&str," AS sub");
+#endif
 	}
 
 	/* Get a subquery representing pre-state of the table */
@@ -1880,7 +1882,6 @@ makeDeltaTable(RangeTblEntry *rte, MV_TriggerTable *table,
 	/* Create a ParseState for rewriting the view definition query */
 	pstate = make_parsestate(NULL);
 	pstate->p_queryEnv = queryEnv;
-	pstate->p_expr_kind = EXPR_KIND_SELECT_TARGET;
 
 	/*
 	 * Add a pseudo ctid to ENR using row_number(), which is required for
@@ -1912,6 +1913,9 @@ makeDeltaTable(RangeTblEntry *rte, MV_TriggerTable *table,
 			make_delta_enr_name(prefix_except, table->table_id, i));
 	}
 	appendStringInfo(&str,")");
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM < 160000)
+	appendStringInfo(&str," AS sub");
+#endif
 
 #if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 140000)
 	raw = (RawStmt*)linitial(raw_parser(str.data, RAW_PARSE_DEFAULT));


### PR DESCRIPTION
Fix a view maintenance failure due to a missing subquery alias. 
With PostgreSQL 15 or earlier, view maintenance failed with the following error:

 ERROR:  subquery in FROM must have an alias

This bug was introduced in 48c71bba.

Also, fix expected file for PostgreSQL 17 or eariler that is overlooked in the previous commit.