### PR TITLE
Add IMMV metadata restore support for pg_dump and pg_upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ DATA = pg_ivm--1.0.sql \
        pg_ivm--1.9--1.10.sql \
        pg_ivm--1.10.sql \
        pg_ivm--1.10--1.11.sql pg_ivm--1.11--1.12.sql pg_ivm--1.12--1.13.sql \
-       pg_ivm--1.13--1.14.sql
+       pg_ivm--1.13--1.14.sql pg_ivm--1.14--1.15.sql
+SCRIPTS = scripts/pg_ivm_dump_metadata
 
 REGRESS = pg_ivm create_immv refresh_immv outer_join
 

--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ When `pg_ivm` is installed, the 'pgivm' schema is created, along with the follow
 
 ### Functions
 
-#### create_immv
+#### `create_immv`
 
 Use `create_immv` function to create IMMV.
 ```
-pgivm.create_immv(immv_name text, view_definition text) RETURNS bigint
+pgivm.create_immv(immv text, view_definition text) RETURNS bigint
 ```
 `create_immv` defines a new IMMV of a query. A table of the name `immv_name` is created and a query specified by `view_definition` is executed and used to populate the IMMV. The query is stored in `pg_ivm_immv`, so that it can be refreshed later upon incremental view maintenance. `create_immv` returns the number of rows in the created IMMV.
 
@@ -111,27 +111,80 @@ When an IMMV is created, some triggers are automatically created so that the vie
 
 Note that if you use PostgreSQL 17 or later, while `create_immv` is running, the `search_path` is temporarily changed to `pg_catalog, pg_temp`.
 
-#### refresh_immv
+#### `restore_immv`
+
+Use `restore_immv` function to restores `pg_ivm` metadata for an existing IMMV.
+```
+pgivm.restore_immv(immv text, view_definition text, populate boolean DEFAULT false) RETURNS void
+```
+
+Unlike `create_immv()`, this function assumes that the IMMV table already exists. It recreates the metadata, triggers, and indexes required by `pg_ivm` without recreating the IMMV table itself.
+
+If `populate` is false (default), existing table contents are preserved, assuming that the table already contains correct data.  If `populate` is true, the contents of the IMMV are regenerated from the view definition.
+
+`restore_immv()` fails if the relation is already registered as an IMMV or if the existing table definition does not match the supplied view definition.
+
+#### `refresh_immv`
 
 Use `refresh_immv` function to refresh IMMV.
 ```
-pgivm.refresh_immv(immv_name text, with_data bool) RETURNS bigint
+pgivm.refresh_immv(immv text, with_data boolean DEFAULT true) RETURNS bigint
 ```
 
 `refresh_immv` completely replaces the contents of an IMMV as `REFRESH MATERIALIZED VIEW` command does for a materialized view. To execute this function you must be the owner of the IMMV (with PostgreSQL 16 or earlier) or have the `MAINTAIN` privilege on the IMMV (with PostgreSQL 17 or later).  The old contents are discarded.
 
-The with_data flag is corresponding to `WITH [NO] DATA` option of `REFRESH MATERIALIZED VIEW` command. If with_data is true, the backing query is executed to provide the new data, and if the IMMV is unpopulated, triggers for maintaining the view are created. Also, a unique index is created for IMMV if it is possible and the view doesn't have that yet. If with_data is false, no new data is generated and the IMMV become unpopulated, and the triggers are dropped from the IMMV. Note that unpopulated IMMV is still scannable although the result is empty. This behaviour may be changed in future to raise an error when an unpopulated IMMV is scanned.
+The `with_data` flag is corresponding to `WITH [NO] DATA` option of `REFRESH MATERIALIZED VIEW` command. If `with_data` is true (default), the backing query is executed to provide the new data, and if the IMMV is unpopulated, triggers for maintaining the view are created. Also, a unique index is created for IMMV if it is possible and the view doesn't have that yet. If `with_data` is false, no new data is generated and the IMMV become unpopulated, and the triggers are dropped from the IMMV. Note that unpopulated IMMV is still scannable although the result is empty. This behaviour may be changed in future to raise an error when an unpopulated IMMV is scanned.
 
 `refresh_immv` acquires `AccessExclusiveLock` on the view. However, even if we are able to acquire the lock, a concurrent transaction may have already incrementally updated and committed the view before we can acquire the lock.  In `REPEATABLE READ` or `SERIALIZABLE` isolation level, this could lead to an inconsistent state of the view. Therefore, an error is raised to prevent anomalies when this situation is detected.
 
 Note that if you use PostgreSQL 17 or later, while `refresh_immv` is running, the `search_path` is temporarily changed to `pg_catalog, pg_temp`.
 
-#### get_immv_def
+#### `get_immv_def`
 
 `get_immv_def` reconstructs the underlying SELECT command for an IMMV. (This is a decompiled reconstruction, not the original text of the command.)
 ```
-pgivm.get_immv_def(immv regclass) RETURNS text
+pgivm.get_immv_def(immvrelid regclass) RETURNS text
 ```
+
+#### `get_create_immv_commands`
+
+```
+pgivm.get_create_immv_commands() RETURNS SETOF text
+```
+
+Returns SQL commands that invoke `pgivm.create_immv()` to recreate all IMMVs.
+
+#### `get_restore_immv_commands`
+
+```
+pgivm.get_restore_immv_commands() RETURNS SETOF text
+```
+
+Returns SQL commands that invoke `pgivm.restore_immv()` to restore IMMV metadata after `pg_dump` or `pg_upgrade`.
+
+### Script
+
+#### `pg_ivm_dump_metadata`
+
+Generate SQL commands that invoke `pgivm.restore_immv()` for all IMMVs in the database.
+
+The metadata stored in `pgivm.pg_ivm_immv` contains an internal query representation generated by PostgreSQL. Since this representation may change across PostgreSQL versions, the contents of `pgivm.pg_ivm_immv` are not included in `pg_dump` output.
+
+Before running `pg_dump` or `pg_upgrade`:
+
+```bash
+$ pg_ivm_dump_metadata mydb > immv_restore.sql
+```
+
+After restoring the database from `pg_dump` or completing `pg_upgrade`:
+
+```bash
+$ psql mydb -f immv_restore.sql
+```
+
+The generated script recreates the metadata, triggers, and indexes required by `pg_ivm` without recreating the IMMV table itself.
+
+Note that IMMV contents themselves are still dumped and restored as ordinary table data. Only the metadata stored in `pgivm.pg_ivm_immv` is excluded from `pg_dump` output.
 
 ### IMMV metadata catalog
 
@@ -336,10 +389,6 @@ test=# SELECT immvrelid AS immv, pgivm.get_immv_def(immvrelid) AS immv_def FROM 
            |   GROUP BY pgbench_accounts.bid
 (1 row)
 ```
-
-## `pg_dump` and `pg_upgrade`
-
-After restoring data from a `pg_dump` backup or upgrading `PostgreSQL` using `pg_upgrade`, all IMMVs must be manually dropped and recreated.
 
 ## Supported View Definitions and Restriction
 

--- a/createas.c
+++ b/createas.c
@@ -172,7 +172,7 @@ create_immv_internal(List *attrList, IntoClause *into)
 /*
  * create_immv_nodata
  *
- * Create an IMMV  when WITH NO DATA is used, starting from
+ * Create an IMMV when WITH NO DATA is used, starting from
  * the targetlist of the view definition.
  *
  * This imitates PostgreSQL's create_ctas_nodata().
@@ -241,6 +241,60 @@ create_immv_nodata(List *tlist, IntoClause *into)
 	return create_immv_internal(attrList, into);
 }
 
+static void
+check_immv_compatibility(Oid matviewOid, List *tlist, IntoClause *into)
+{
+	Relation	matviewRel;
+	TupleDesc	tupdesc;
+	ListCell   *t;
+	int			i;
+
+	Assert(into->colNames == NULL);
+
+	matviewRel = table_open(matviewOid, NoLock);
+	tupdesc = matviewRel->rd_att;
+
+	i = 0;
+	foreach(t, tlist)
+	{
+		TargetEntry *tle = (TargetEntry *) lfirst(t);
+		Form_pg_attribute attr;
+
+		if (tle->resjunk)
+			continue;
+
+		do {
+			if (i >= tupdesc->natts)
+				ereport(ERROR,
+						(errcode(ERRCODE_DATATYPE_MISMATCH),
+						 errmsg("table is missing column \"%s\"",
+								tle->resname)));
+			attr = TupleDescAttr(tupdesc, i);
+			i++;
+		} while (attr->attisdropped);
+
+		if (strcmp(NameStr(attr->attname), tle->resname) != 0 ||
+			attr->atttypid != exprType((Node *) tle->expr) ||
+			attr->atttypmod != exprTypmod((Node *) tle->expr) ||
+			attr->attcollation != exprCollation((Node *) tle->expr))
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_DATATYPE_MISMATCH),
+					 errmsg("table definition mismatch with view definition"),
+					 errdetail("The column \"%s\" differs from the view definition.",
+							   tle->resname)));
+		}
+	}
+
+	while (TupleDescAttr(tupdesc, i)->attisdropped)
+		i++;
+	if (i < tupdesc->natts)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATATYPE_MISMATCH),
+				errmsg("too many columns in table")));
+
+	table_close(matviewRel, NoLock);
+}
 
 /*
  * ExecCreateImmv -- execute a create_immv() function
@@ -249,16 +303,33 @@ create_immv_nodata(List *tlist, IntoClause *into)
  */
 ObjectAddress
 ExecCreateImmv(ParseState *pstate, CreateTableAsStmt *stmt,
-				  QueryCompletion *qc)
+				  QueryCompletion *qc, Oid matviewOid)
 {
 	Query	   *query = castNode(Query, stmt->query);
 	IntoClause *into = stmt->into;
 	bool		do_refresh = false;
 	ObjectAddress address;
+	Relation matviewRel;
 
-	/* Check if the relation exists or not */
-	if (CreateTableAsRelExists(stmt))
-		return InvalidObjectAddress;
+	if (!OidIsValid(matviewOid))
+	{
+		/* Check if the relation exists or not */
+		if (CreateTableAsRelExists(stmt))
+			return InvalidObjectAddress;
+	}
+	else
+	{
+		matviewRel = table_open(matviewOid, NoLock);
+
+		/* check if metadata not exists */
+		if (get_immv_query(matviewRel))
+			ereport(ERROR,
+					(errcode(ERRCODE_DUPLICATE_OBJECT),
+					 errmsg("relation \"%s\" is already registered as an IMMV",
+							into->rel->relname)));
+
+		table_close(matviewRel, NoLock);
+	}
 
 	/*
 	 * The contained Query must be a SELECT.
@@ -268,6 +339,8 @@ ExecCreateImmv(ParseState *pstate, CreateTableAsStmt *stmt,
 	/*
 	 * For materialized views, always skip data during table creation, and use
 	 * REFRESH instead (see below).
+	 *
+	 * do_refresh is set to true for create_immv, or restore_immv with populate.
 	 */
 	do_refresh = !into->skipData;
 
@@ -283,35 +356,50 @@ ExecCreateImmv(ParseState *pstate, CreateTableAsStmt *stmt,
 	/* For IMMV, we need to rewrite matview query */
 	query = rewriteQueryForIMMV(query, into->colNames);
 
-	/*
-	 * If WITH NO DATA was specified, do not go through the rewriter,
-	 * planner and executor.  Just define the relation using a code path
-	 * similar to CREATE VIEW.  This avoids dump/restore problems stemming
-	 * from running the planner before all dependencies are set up.
-	 */
-	address = create_immv_nodata(query->targetList, into);
+	if (!OidIsValid(matviewOid))
+		/*
+		 * If WITH NO DATA was specified, do not go through the rewriter,
+		 * planner and executor.  Just define the relation using a code path
+		 * similar to CREATE VIEW.  This avoids dump/restore problems stemming
+		 * from running the planner before all dependencies are set up.
+		 */
+		address = create_immv_nodata(query->targetList, into);
+	else
+	{
+		/* check table compatibility */
+		check_immv_compatibility(matviewOid, query->targetList, into);
+
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 180000)
+		StoreImmvQuery(matviewOid, into->viewQuery);
+#else
+		StoreImmvQuery(matviewOid, (Query *) into->viewQuery);
+#endif
+	}
 
 	/*
+	 * For create_immv or restore_immv with populate = true, generate
+	 * data by executing the view definition query.
+	 *
 	 * For materialized views, reuse the REFRESH logic, which locks down
 	 * security-restricted operations and restricts the search_path.  This
 	 * reduces the chance that a subsequent refresh will fail.
 	 */
 	if (do_refresh)
 	{
-		Relation matviewRel;
+		Oid relid = OidIsValid(matviewOid) ? matviewOid: address.objectId;
 
-		RefreshImmvByOid(address.objectId, true, false, pstate->p_sourcetext, qc);
+		RefreshImmvByOid(relid, true, false, pstate->p_sourcetext, qc);
 
 		if (qc)
 			qc->commandTag = CMDTAG_SELECT;
 
-		matviewRel = table_open(address.objectId, NoLock);
+		matviewRel = table_open(relid, NoLock);
 
 		/* Create an index on incremental maintainable materialized view, if possible */
 		CreateIndexOnIMMV(query, matviewRel);
 
 		/* Create triggers to prevent IMMV from being changed */
-		CreateChangePreventTrigger(address.objectId);
+		CreateChangePreventTrigger(relid);
 
 		table_close(matviewRel, NoLock);
 
@@ -321,6 +409,27 @@ ExecCreateImmv(ParseState *pstate, CreateTableAsStmt *stmt,
 					 errdetail("The view may not include effects of a concurrent transaction."),
 					 errhint("create_immv should be used in isolation level READ COMMITTED, "
 							 "or execute refresh_immv to make sure the view is consistent.")));
+	}
+	/*
+	 * For restore_immv with populate = false (default), only restore
+	 * the metadata to pg_ivm_immv and create the maintenance triggers
+	 * and an index if possible.
+	 */
+	else
+	{
+		Assert(OidIsValid(matviewOid));
+
+		CreateIvmTriggersOnBaseTables(query, matviewOid);
+
+		matviewRel = table_open(matviewOid, NoLock);
+
+		/* Create an index on incremental maintainable materialized view, if possible */
+		CreateIndexOnIMMV(query, matviewRel);
+
+		/* Create triggers to prevent IMMV from being changed */
+		CreateChangePreventTrigger(matviewOid);
+
+		table_close(matviewRel, NoLock);
 	}
 
 	return address;

--- a/pg_ivm--1.14--1.15.sql
+++ b/pg_ivm--1.14--1.15.sql
@@ -1,0 +1,73 @@
+-- pg_ivm_immv contents must not be dumped during pg_dump
+ALTER EXTENSION pg_ivm DROP TABLE pgivm.pg_ivm_immv;
+ALTER EXTENSION pg_ivm ADD TABLE pgivm.pg_ivm_immv;
+
+CREATE OR REPLACE FUNCTION pgivm.create_immv(
+	immv text,
+	view_definition text
+)
+RETURNS bigint
+STRICT
+AS 'MODULE_PATHNAME', 'create_immv'
+LANGUAGE C;
+
+CREATE OR REPLACE FUNCTION pgivm.restore_immv(
+	immv text,
+	view_definition text,
+	populate boolean DEFAULT false
+)
+RETURNS void
+STRICT
+AS 'MODULE_PATHNAME', 'restore_immv'
+LANGUAGE C;
+
+CREATE OR REPLACE FUNCTION pgivm.refresh_immv(
+	immv text,
+	with_data boolean DEFAULT true
+)
+RETURNS bigint
+STRICT
+AS 'MODULE_PATHNAME', 'refresh_immv'
+LANGUAGE C;
+
+CREATE FUNCTION pgivm.get_create_immv_commands()
+RETURNS SETOF text
+LANGUAGE sql
+SET search_path = ''
+AS $$
+SELECT format(
+    'SELECT pgivm.create_immv(' || E'\n' ||
+	'    immv => %L,' || E'\n' ||
+	'    view_definition => %L' || E'\n' ||
+	');',
+    format('%I.%I', n.nspname, c.relname),
+    pgivm.get_immv_def(c.oid)
+)
+FROM pgivm.pg_ivm_immv i
+JOIN pg_catalog.pg_class c
+  ON c.oid = i.immvrelid
+JOIN pg_catalog.pg_namespace n
+  ON n.oid = c.relnamespace
+ORDER BY n.nspname, c.relname;
+$$;
+
+CREATE FUNCTION pgivm.get_restore_immv_commands()
+RETURNS SETOF text
+LANGUAGE sql
+SET search_path = ''
+AS $$
+SELECT format(
+    'SELECT pgivm.restore_immv(' || E'\n' ||
+	'    immv => %L,' || E'\n' ||
+	'    view_definition => %L' || E'\n' ||
+	');',
+    format('%I.%I', n.nspname, c.relname),
+    pgivm.get_immv_def(c.oid)
+)
+FROM pgivm.pg_ivm_immv i
+JOIN pg_catalog.pg_class c
+  ON c.oid = i.immvrelid
+JOIN pg_catalog.pg_namespace n
+  ON n.oid = c.relnamespace
+ORDER BY n.nspname, c.relname;
+$$;

--- a/pg_ivm.c
+++ b/pg_ivm.c
@@ -20,6 +20,7 @@
 #include "catalog/objectaccess.h"
 #include "catalog/pg_namespace_d.h"
 #include "catalog/pg_trigger_d.h"
+#include "commands/tablecmds.h"
 #include "commands/trigger.h"
 #include "parser/analyze.h"
 #include "parser/parser.h"
@@ -53,6 +54,7 @@ static void PgIvmObjectAccessHook(ObjectAccessType access, Oid classId,
 
 /* SQL callable functions */
 PG_FUNCTION_INFO_V1(create_immv);
+PG_FUNCTION_INFO_V1(restore_immv);
 PG_FUNCTION_INFO_V1(refresh_immv);
 PG_FUNCTION_INFO_V1(IVM_prevent_immv_change);
 PG_FUNCTION_INFO_V1(get_immv_def);
@@ -234,9 +236,94 @@ create_immv(PG_FUNCTION_ARGS)
 	query = transformStmt(pstate, (Node *) ctas);
 	Assert(query->commandType == CMD_UTILITY && IsA(query->utilityStmt, CreateTableAsStmt));
 
-	ExecCreateImmv(pstate, (CreateTableAsStmt *) query->utilityStmt, &qc);
+	ExecCreateImmv(pstate, (CreateTableAsStmt *) query->utilityStmt, &qc, InvalidOid);
 
 	PG_RETURN_INT64(qc.nprocessed);
+}
+
+/*
+ * User interface for restoring metadata to an IMMV
+ */
+Datum
+restore_immv(PG_FUNCTION_ARGS)
+{
+	text	*t_relname = PG_GETARG_TEXT_PP(0);
+	text	*t_sql = PG_GETARG_TEXT_PP(1);
+	bool	populate = PG_GETARG_BOOL(2);
+	char	*relname = text_to_cstring(t_relname);
+	char	*sql = text_to_cstring(t_sql);
+	List	*parsetree_list;
+	RawStmt	*parsetree;
+	Query	*query;
+
+	RangeVar	*immv;
+	Oid			matviewOid;
+
+	ParseState *pstate = make_parsestate(NULL);
+	CreateTableAsStmt *ctas;
+	StringInfoData command_buf;
+
+	immv = makeRangeVarFromNameList(textToQualifiedNameList(t_relname));
+
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM < 170000)
+	matviewOid = RangeVarGetRelidExtended(immv,
+										  AccessExclusiveLock, 0,
+										  RangeVarCallbackOwnsTable,
+										  NULL);
+#else
+	matviewOid = RangeVarGetRelidExtended(immv,
+										  AccessExclusiveLock, 0,
+										  RangeVarCallbackMaintainsTable,
+										  NULL);
+#endif
+
+	initStringInfo(&command_buf);
+	appendStringInfo(&command_buf, "SELECT restore_immv('%s', '%s');", relname, sql);
+	appendStringInfo(&command_buf, "%s;", sql);
+	pstate->p_sourcetext = command_buf.data;
+
+	parsetree_list = pg_parse_query(sql);
+
+	/* XXX: should we check t_sql before command_buf? */
+	if (list_length(parsetree_list) != 1)
+		elog(ERROR, "invalid view definition");
+
+	parsetree = linitial_node(RawStmt, parsetree_list);
+
+	/* view definition should specify SELECT query */
+	if (!IsA(parsetree->stmt, SelectStmt))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("view definition must specify SELECT statement")));
+
+	ctas = makeNode(CreateTableAsStmt);
+	ctas->query = parsetree->stmt;
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 140000)
+	ctas->objtype = OBJECT_MATVIEW;
+#else
+	ctas->relkind = OBJECT_MATVIEW;
+#endif
+	ctas->is_select_into = false;
+	ctas->into = makeNode(IntoClause);
+	ctas->into->rel = immv;
+	ctas->into->colNames = NIL;
+	ctas->into->accessMethod = NULL;
+	ctas->into->options = NIL;
+	ctas->into->onCommit = ONCOMMIT_NOOP;
+	ctas->into->tableSpaceName = NULL;
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 180000)
+	ctas->into->viewQuery = (Query *) parsetree->stmt;
+#else
+	ctas->into->viewQuery = parsetree->stmt;
+#endif
+	ctas->into->skipData = !populate;
+
+	query = transformStmt(pstate, (Node *) ctas);
+	Assert(query->commandType == CMD_UTILITY && IsA(query->utilityStmt, CreateTableAsStmt));
+
+	ExecCreateImmv(pstate, (CreateTableAsStmt *) query->utilityStmt, NULL, matviewOid);
+
+	PG_RETURN_VOID();
 }
 
 /*

--- a/pg_ivm.control
+++ b/pg_ivm.control
@@ -1,6 +1,6 @@
 # incremental view maintenance extension
 comment = 'incremental view maintenance on PostgreSQL'
-default_version = '1.14'
+default_version = '1.15'
 module_pathname = '$libdir/pg_ivm'
 relocatable = false 
 schema = pg_catalog

--- a/pg_ivm.h
+++ b/pg_ivm.h
@@ -38,7 +38,7 @@ extern List *PgIvmFuncName(char *name);
 /* createas.c */
 
 extern ObjectAddress ExecCreateImmv(ParseState *pstate, CreateTableAsStmt *stmt,
-									QueryCompletion *qc);
+									QueryCompletion *qc, Oid matviewOid);
 extern void CreateIvmTriggersOnBaseTables(Query *qry, Oid matviewOid);
 extern void CreateIndexOnIMMV(Query *query, Relation matviewRel);
 extern Query *rewriteQueryForIMMV(Query *query, List *colNames);

--- a/scripts/pg_ivm_dump_metadata
+++ b/scripts/pg_ivm_dump_metadata
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+psql "$@" -XAtqc \
+'SELECT * FROM pgivm.get_restore_immv_commands()'


### PR DESCRIPTION
Previously, after restoring a database from pg_dump or upgrading PostgreSQL using pg_upgrade, all IMMVs had to be manually dropped and recreated.

This is because pg_ivm_immv stores PostgreSQL internal query representations, which may change across PostgreSQL versions. Furthermore, pg_dump does not dump the triggers and indexes required for incremental maintenance.

To address this, stop dumping the contents of pg_ivm_immv and add restore_immv(), helper SQL functions, and the
pg_ivm_dump_metadata script to generate SQL commands for restoring the metadata, triggers, and indexes after restore or upgrade.

As part of this change, improve the SQL function interfaces by adding argument names and default values where appropriate.

(#issue 118)