### PR TITLE
Fix build against PostgreSQL 19 (REPACK command merge + pg_plan_query signature change

### DIFF
--- a/createas.c
+++ b/createas.c
@@ -1838,7 +1838,12 @@ CreateIndexOnIMMV(Query *query, Relation matviewRel)
 			return;
 	}
 
-	address = DefineIndex(RelationGetRelid(matviewRel),
+	address = DefineIndex(
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 190000)
+						  NULL,	/* pstate; no parse state for this
+								 * internally generated index */
+#endif
+						  RelationGetRelid(matviewRel),
 						  index,
 						  InvalidOid,
 						  InvalidOid,

--- a/matview.c
+++ b/matview.c
@@ -20,7 +20,14 @@
 #include "catalog/heap.h"
 #include "catalog/pg_collation_d.h"
 #include "catalog/pg_trigger.h"
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 190000)
+#include "commands/repack.h"	/* commands/cluster.h was renamed to
+								 * commands/repack.h when CLUSTER/VACUUM
+								 * FULL were merged into the new REPACK
+								 * command */
+#else
 #include "commands/cluster.h"
+#endif
 #include "commands/defrem.h"
 #include "commands/matview.h"
 #include "commands/tablecmds.h"
@@ -645,7 +652,11 @@ refresh_immv_datafill(DestReceiver *dest, Query *query,
 	CHECK_FOR_INTERRUPTS();
 
 	/* Plan the query which will generate data for the refresh. */
-	plan = pg_plan_query(query, queryString, CURSOR_OPT_PARALLEL_OK, NULL);
+	plan = pg_plan_query(query, queryString, CURSOR_OPT_PARALLEL_OK, NULL
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 190000)
+						 , NULL		/* es; not under EXPLAIN */
+#endif
+						 );
 
 	/*
 	 * Use a snapshot with an updated command ID to ensure this query sees
@@ -696,6 +707,9 @@ static void
 refresh_by_heap_swap(Oid matviewOid, Oid OIDNewHeap, char relpersistence)
 {
 	finish_heap_swap(matviewOid, OIDNewHeap, false, false, true, true,
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 190000)
+					 true,		/* reindex */
+#endif
 					 RecentXmin, ReadNextMultiXactId(), relpersistence);
 }
 


### PR DESCRIPTION
 PG19 merged CLUSTER and VACUUM FULL into the new in-core REPACK
 command (see "Introduce the REPACK command", PG19). As part of that
 work, src/include/commands/cluster.h was renamed to
 src/include/commands/repack.h, and two functions pg_ivm relies on
 changed shape as a result. Separately, pg_plan_query() also grew a
 new trailing parameter in PG19.

   1. matview.c - #include "commands/cluster.h" no longer exists on PG19; guarded the include to pull in "commands/repack.h" instead when building against PG19+, keeping the old include for PG18 and earlier. - finish_heap_swap() gained a new `bool reindex` parameter (inserted after `is_internal`, before `frozenXid`) in repack.h. Inserted a PG19+-guarded `true` argument at that position within the single call; refresh_by_heap_swap() always reindexed before, so `true` preserves existing behavior. - pg_plan_query() gained a new trailing `ExplainState *es` parameter in tcop/tcopprot.h. Appended a PG19+-guarded `NULL` argument within the single call; this call site is not under EXPLAIN, matching how core matview.c calls it.

   2. createas.c
      - DefineIndex() gained a new leading `ParseState *pstate` parameter in PG19's defrem.h. Prepended a PG19+-guarded `NULL` argument within the single call, matching how core tablecmds.c calls it for internally generated indexes.

 All changes are guarded with `#if defined(PG_VERSION_NUM) &&
 (PG_VERSION_NUM >= 190000)` so the extension still builds
 unmodified against PG13-PG18.