### PR TITLE
Fix a segfault when an IMMV is maintained and dropped in the same tra…

### DIFF
--- a/matview.c
+++ b/matview.c
@@ -4201,7 +4201,7 @@ insert_dangling_tuples(List *terms, Query *query,
 			 */
 			if (bms_is_subset(tle_relids, term->relids))
 				appendStringInfo(&targetlist, "%s%s", targetlist.len ? "," : "", resname);
-			
+
 			bms_free(tle_relids);
 		}
 
@@ -4892,22 +4892,30 @@ setLastUpdateXid(Oid immv_oid, FullTransactionId xid)
 								  true, NULL, 1, &key);
 	tup = systable_getnext(scan);
 
-	memset(values, 0, sizeof(values));
-	values[Anum_pg_ivm_immv_lastivmupdate -1 ] = FullTransactionIdGetDatum(xid);
-	MemSet(nulls, false, sizeof(nulls));
-	MemSet(replaces, false, sizeof(replaces));
-	replaces[Anum_pg_ivm_immv_lastivmupdate -1 ] = true;
-
-	newtup = heap_modify_tuple(tup, tupdesc, values, nulls, replaces);
-
-	CatalogTupleUpdate(pgIvmImmv, &newtup->t_self, newtup);
-	heap_freetuple(newtup);
-
 	/*
-	 * Advance command counter to make the updated pg_ivm_immv row locally
-	 * visible.
+	 * Update the transaction ID if the catalog has an entry for the view.
+	 * If the view has been dropped in the same transaction in which it was
+	 * maintained, the entry no longer exists.
 	 */
-	CommandCounterIncrement();
+	if (HeapTupleIsValid(tup))
+	{
+		memset(values, 0, sizeof(values));
+		values[Anum_pg_ivm_immv_lastivmupdate -1 ] = FullTransactionIdGetDatum(xid);
+		MemSet(nulls, false, sizeof(nulls));
+		MemSet(replaces, false, sizeof(replaces));
+		replaces[Anum_pg_ivm_immv_lastivmupdate -1 ] = true;
+
+		newtup = heap_modify_tuple(tup, tupdesc, values, nulls, replaces);
+
+		CatalogTupleUpdate(pgIvmImmv, &newtup->t_self, newtup);
+		heap_freetuple(newtup);
+
+		/*
+		 * Advance command counter to make the updated pg_ivm_immv row locally
+		 * visible.
+		 */
+		CommandCounterIncrement();
+	}
 
 	systable_endscan(scan);
 	table_close(pgIvmImmv, ShareRowExclusiveLock);

--- a/pg_ivm.c
+++ b/pg_ivm.c
@@ -481,7 +481,7 @@ PgIvmObjectAccessHook(ObjectAccessType access, Oid classId,
 		ScanKeyData key;
 		HeapTuple tup;
 		Oid pgIvmImmvOid = PgIvmImmvRelationId();
-	
+
 		Oid pgIvmImmvPkOid = PgIvmImmvPrimaryKeyIndexId();
 
 		/*
@@ -492,7 +492,7 @@ PgIvmObjectAccessHook(ObjectAccessType access, Oid classId,
 		 */
 		if (pgIvmImmvPkOid == InvalidOid || pgIvmImmvOid == InvalidOid)
 			return;
-		
+
 		pgIvmImmv = table_open(pgIvmImmvOid, AccessShareLock);
 		ScanKeyInit(&key,
 					Anum_pg_ivm_immv_immvrelid,


### PR DESCRIPTION
…nsaction

The segfault occurred when trying to update pg_ivm_immv.lastivmupdate after the pg_ivm_immv entry for the IMMV had already been removed.

Issue #171