### PR TITLE
Improve stability of SERIALIZABLE isolation tests

### DIFF
--- a/matview.c
+++ b/matview.c
@@ -4966,6 +4966,15 @@ getLastUpdateXid(Oid immv_oid)
 	if (!isnull)
 		xid = DatumGetFullTransactionId(datum);
 
+	/*
+	 * Only one tuple should match because of the primary key. Calling
+	 * systable_getnext() once more to confirm that no additional tuples are
+	 * visible triggers an RW-conflict check under SERIALIZABLE, improving the
+	 * stability of the isolation test.
+	 */
+	tup = systable_getnext(scan);
+	Assert(!HeapTupleIsValid(tup));
+
 	systable_endscan(scan);
 	table_close(pgIvmImmv, NoLock);
 


### PR DESCRIPTION
When getLastUpdateXid() uses a latest catalog snapshot under SERIALIZABLE, whether an RW-conflict is recorded may depend on the HOT tuple layout. Previously, the function stopped after finding the expected tuple, so it could miss an invisible tuple that would trigger an RW-conflict check.

Modified the function to call systable_getnext() once more after finding the expected tuple and confirm that no additional tuples are returned. This causes any remaining tuples to be checked for visibility, reducing the dependency on the HOT tuple layout and improving the stability of the isolation tests.