### PR TITLE
Fix OID handling when OID exceeds INT_MAX

### DIFF
--- a/createas.c
+++ b/createas.c
@@ -79,7 +79,7 @@ typedef struct
 } check_ivm_restriction_context;
 
 static void CreateIvmTriggersOnBaseTablesRecurse(Query *qry, Node *node, Oid matviewOid,
-									 Relids *relids, bool ex_lock);
+									 List **relids, bool ex_lock);
 static void CreateIvmTrigger(Oid relOid, Oid viewOid, int16 type, int16 timing, bool ex_lock);
 static void check_ivm_restriction(Node *node);
 static bool check_ivm_restriction_walker(Node *node, check_ivm_restriction_context *context);
@@ -673,7 +673,7 @@ makeIvmAggColumn(ParseState *pstate, Aggref *aggref, char *resname, AttrNumber *
 void
 CreateIvmTriggersOnBaseTables(Query *qry, Oid matviewOid)
 {
-	Relids	relids = NULL;
+	List   *relids = NIL;
 	bool	ex_lock = false;
 	RangeTblEntry *rte;
 
@@ -707,12 +707,12 @@ CreateIvmTriggersOnBaseTables(Query *qry, Oid matviewOid)
 
 	CreateIvmTriggersOnBaseTablesRecurse(qry, (Node *)qry, matviewOid, &relids, ex_lock);
 
-	bms_free(relids);
+	list_free(relids);
 }
 
 static void
 CreateIvmTriggersOnBaseTablesRecurse(Query *qry, Node *node, Oid matviewOid,
-									 Relids *relids, bool ex_lock)
+									 List  **relids, bool ex_lock)
 {
 	if (node == NULL)
 		return;
@@ -742,7 +742,7 @@ CreateIvmTriggersOnBaseTablesRecurse(Query *qry, Node *node, Oid matviewOid,
 				int			rti = ((RangeTblRef *) node)->rtindex;
 				RangeTblEntry *rte = rt_fetch(rti, qry->rtable);
 
-				if (rte->rtekind == RTE_RELATION && !bms_is_member(rte->relid, *relids))
+				if (rte->rtekind == RTE_RELATION && !list_member_oid(*relids, rte->relid))
 				{
 					CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_INSERT, TRIGGER_TYPE_BEFORE, ex_lock);
 					CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_DELETE, TRIGGER_TYPE_BEFORE, ex_lock);
@@ -753,7 +753,7 @@ CreateIvmTriggersOnBaseTablesRecurse(Query *qry, Node *node, Oid matviewOid,
 					CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_UPDATE, TRIGGER_TYPE_AFTER, ex_lock);
 					CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_TRUNCATE, TRIGGER_TYPE_AFTER, true);
 
-					*relids = bms_add_member(*relids, rte->relid);
+					*relids = lappend_oid(*relids, rte->relid);
 				}
 				else if (rte->rtekind == RTE_SUBQUERY)
 				{

--- a/matview.c
+++ b/matview.c
@@ -1743,7 +1743,7 @@ get_prestate_rte(RangeTblEntry *rte, MV_TriggerTable *table,
 	initStringInfo(&str);
 	appendStringInfo(&str,
 		"SELECT %s, ctid::text FROM %s t"
-		" WHERE pgivm.ivm_visible_in_prestate(t.tableoid, t.ctid, %d::pg_catalog.oid)",
+		" WHERE pgivm.ivm_visible_in_prestate(t.tableoid, t.ctid, %u::pg_catalog.oid)",
 			subquery_tl, relname, matviewid);
 
 	/*


### PR DESCRIPTION
Once PostgreSQL global OID counter exceeds INT_MAX following fails:

- creating new IMMVs.
- `INSERT`/`UPDATE`/`DELETE` for tables that have IVM_immediate_maintenance triggers, when table was created  before counter exceeded INT_MAX and IMMV was created after counter exceeded INT_MAX. 

Reason is how OID is converted to signed `int` argument or string with `%d` specifier. If OID is above INT_MAX, it is converted to/rendered as negative number. 

## matview.c:
**Error:** operator does not exist: - oid

**Why:**  OID above INT_MAX will be converted and render as negative number when `%d` specifier is used. This results in a query with `-<number>::pg_catalog.oid` passed to backend. This is parsed as `-` operator on something that is of type OID, PostgreSQL doesn't have unary minus operator defined for OID (due to OID's unsigned nature) and errors out. 

**Fix:** I substituted `%d` specifier with `%u`, so it correctly substituted without negative conversion. 

## createas.c:
**Error:** negative bitmapset member not allowed

**Why:** `bms_is_member` takes `int`. OID above INT_MAX is converted to `int` with negative value, `x < 0` guard in `bms_is_member` kicks in and errors out. 

**Fix:** Found that in core patches there was already work done to replace BitMapSet with list, so I took the fix from there verbatim: https://www.postgresql.org/message-id/attachment/200982/v40-0003-Add-Incremental-View-Maintenance-support.patch