### PR TITLE
Disallow property graphs in view definition queries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ REGRESS = pg_ivm create_immv refresh_immv outer_join
 
 PGVER = $(shell $(PG_CONFIG) --version | sed "s/^[^ ]* \([0-9]*\).*$$/\1/" 2>/dev/null)
 
+ifeq ($(shell awk 'BEGIN {print ($(PGVER) >= 19) ? 1 : 0}'), 1)
+REGRESS += graph_table
+endif
+
 # We assume PG13 is the only version that is supported by pg_ivm but
 # missing pg_isolation_regress.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The `pg_ivm` module provides Incremental View Maintenance (IVM) feature for PostgreSQL.
 
-The extension is compatible with PostgreSQL 13, 14, 15, 16, 17, and 18.
+The extension is compatible with PostgreSQL 13, 14, 15, 16, 17, 18, and 19.
 
 ## Description
 
@@ -64,7 +64,7 @@ To install `pg_ivm`, execute this in the module's directory:
 make install
 ```
 
-If you installed PostgreSQL from rpm or deb, you will need the devel package (for example, postgresql14-devel or postgresql-server-dev-14).
+If you installed PostgreSQL from rpm or deb, you will need the devel package (for example, postgresql19-devel or postgresql-server-dev-19).
 
 > **Important:** Don't forget to set the `PG_CONFIG` variable (`make PG_CONFIG=...`) or the `PATH` to the `pg_config` command in case you want to use `pg_ivm` on a non-default or custom build of PostgreSQL. Read more [here](https://wiki.postgresql.org/wiki/Building_and_Installing_PostgreSQL_Extension_Modules).
 
@@ -394,7 +394,7 @@ test=# SELECT immvrelid AS immv, pgivm.get_immv_def(immvrelid) AS immv_def FROM 
 
 Currently, IMMV's view definition can contain inner and outer joins, DISTINCT clause, some built-in aggregate functions, simple sub-queries in `FROM` clause, EXISTS sub-queries, and simple CTE (`WITH` query). Inner joins including self-join are supported. Supported aggregate functions are count, sum, avg, min and max. Other aggregates, sub-queries which contain an aggregate or `DISTINCT` clause, sub-queries in other than `FROM` clause, window functions, `HAVING`, `ORDER BY`, `LIMIT`/`OFFSET`, `UNION`/`INTERSECT`/`EXCEPT`, `DISTINCT ON`, `TABLESAMPLE`, `VALUES`, and `FOR UPDATE`/`SHARE` can not be used in view definition.
 
-The base tables must be simple tables. Views, materialized views, inheritance parent tables, partitioned tables, partitions, and foreign tables can not be used.
+The base tables must be simple tables. Views, materialized views, inheritance parent tables, partitioned tables, partitions, foreign tables, property graph tables can not be used.
 
 Any system column cannot be included in the view definition query.
 The target list cannot columns whose name starts with `__ivm_`.

--- a/createas.c
+++ b/createas.c
@@ -1067,6 +1067,13 @@ check_ivm_restriction_walker(Node *node, check_ivm_restriction_context *context)
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								 errmsg("including IMMV in definition is not supported on incrementally maintainable materialized view")));
 
+#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 190000)
+					if (rte->relkind == RELKIND_PROPGRAPH)
+						ereport(ERROR,
+								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								 errmsg("property graph is not supported on incrementally maintainable materialized view")));
+#endif
+
 					if (rte->rtekind == RTE_SUBQUERY)
 					{
 						context->has_subquery = true;

--- a/expected/graph_table.out
+++ b/expected/graph_table.out
@@ -1,0 +1,5 @@
+-- property graph is not supported
+CREATE TABLE v (i int PRIMARY KEY);
+CREATE PROPERTY GRAPH mygraph VERTEX TABLES (v);
+SELECT pgivm.create_immv('mv', 'SELECT * FROM GRAPH_TABLE (mygraph MATCH (v) COLUMNS (v.i))');
+ERROR:  property graph is not supported on incrementally maintainable materialized view

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,7 @@
-project('pg_ivm', ['c'])
+project('pg_ivm',
+  ['c'],
+  version: '1.15'
+)
 
 pg_config = find_program('pg_config')
 
@@ -8,6 +11,19 @@ includedir = run_command(pg_config, '--includedir', check: true).stdout().strip(
 pkglibdir = run_command(pg_config, '--pkglibdir', check: true).stdout().strip()
 sharedir = run_command(pg_config, '--sharedir', check: true).stdout().strip()
 libdir = run_command(pg_config, '--libdir', check: true).stdout().strip()
+version = run_command(pg_config, '--version', check: true).stdout().strip()
+
+pg_version = version.split(' ')[1]
+
+if pg_version.endswith('devel')
+  pgver = pg_version.split('devel')[0].to_int()
+elif pg_version.contains('beta')
+  pgver = pg_version.split('beta')[0].to_int()
+elif pg_version.contains('rc')
+  pgver = pg_version.split('rc')[0].to_int()
+else
+  pgver = pg_version.split('.')[0].to_int()
+endif
 
 module_name = meson.project_name()
 
@@ -73,6 +89,9 @@ pg_regress = find_program('pg_regress',
 )
 
 regress_tests = ['pg_ivm', 'create_immv', 'refresh_immv', 'outer_join']
+if pgver >= 19
+  regress_tests += ['graph_table']
+endif
 
 test('regress',
  pg_regress,
@@ -95,10 +114,12 @@ isolation_opts = [
   '--load-extension','pg_ivm',
 ]
 
-test('isolation',
- pg_isolation_regress,
- args: ['--bindir', bindir,
-        '--inputdir', meson.current_source_dir(),
-        '--outputdir', 'output_iso',
-       ] + isolation_opts + isolation_tests,
-)
+if pgver >= 14
+  test('isolation',
+   pg_isolation_regress,
+   args: ['--bindir', bindir,
+          '--inputdir', meson.current_source_dir(),
+          '--outputdir', 'output_iso',
+         ] + isolation_opts + isolation_tests,
+  )
+endif

--- a/sql/graph_table.sql
+++ b/sql/graph_table.sql
@@ -1,0 +1,4 @@
+-- property graph is not supported
+CREATE TABLE v (i int PRIMARY KEY);
+CREATE PROPERTY GRAPH mygraph VERTEX TABLES (v);
+SELECT pgivm.create_immv('mv', 'SELECT * FROM GRAPH_TABLE (mygraph MATCH (v) COLUMNS (v.i))');


### PR DESCRIPTION
The rewriter can transform a GRAPH_TABLE into an UNION subquery, but pg_ivm currently does not support views containing set operations. Therefore, reject view definitions that include GRAPH_TABLE.

Add a regresion test for this restriction. Since the property graphsx are new in PG19, run the test only on PG19 or later. Also, adjust Makefile and meson.build accordingly.